### PR TITLE
Add 3D ring carousel styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,3 +9,28 @@
 .site-footer { background: #f5f5f5; }
 
 /* Your custom CSS below */
+
+/* ==== 3D RING CAROUSEL ==== */
+.kc-ring-wrap { background:#fff; }
+.kc-ring-stage{
+  position:relative; perspective:1200px; height: clamp(220px, 36vw, 420px);
+  display:grid; place-items:center; overflow:hidden;
+  /* subtle vignette */
+  background: radial-gradient(1200px 280px at 50% 120%, #f6f8fb 0%, #ffffff 60%);
+  border-radius:16px; box-shadow: 0 10px 24px rgba(0,0,0,.06);
+}
+.kc-ring{ position:relative; transform-style:preserve-3d; width:100%; height:100%; }
+.kc-tile{
+  position:absolute; top:50%; left:50%;
+  transform-style:preserve-3d; translate:-50% -50%;
+  width:clamp(90px, 10vw, 140px); height:clamp(60px, 7vw, 96px);
+  display:grid; place-items:center; background:#fff; border-radius:14px;
+  box-shadow:0 10px 24px rgba(0,0,0,.08), inset 0 1px 0 rgba(255,255,255,.8);
+}
+.kc-tile img { max-width:80%; max-height:70%; filter:grayscale(100%); opacity:.9; transition:.2s; }
+.kc-tile:hover img { filter:none; opacity:1; }
+
+/* Autoplay rotation class added by JS */
+.kc-ring.kc-spin { animation: kc-spin var(--kc-speed, 22s) linear infinite; }
+@keyframes kc-spin { from { transform: rotateY(0deg) } to { transform: rotateY(-360deg) } }
+


### PR DESCRIPTION
## Summary
- add CSS for 3D ring carousel layout and animation

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a64fac63c4832894376e255c167bdf