### PR TITLE
Add theme version utility and display in footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Theme footer template.
+ *
+ * @package Kadence Child
+ */
+?>
+<footer class="site-footer">
+  <div class="site-info">
+    Theme version: <?php echo esc_html( kc_get_theme_version() ); ?>
+  </div>
+</footer>
+
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/utils.php';
 /**
  * Kadence Child – enqueue styles & JS
  */

--- a/utils.php
+++ b/utils.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Utility functions for Kadence Child theme.
+ */
+
+/**
+ * Returns the current theme version.
+ *
+ * @return string Theme version string.
+ */
+function kc_get_theme_version() {
+  return wp_get_theme()->get('Version');
+}


### PR DESCRIPTION
## Summary
- add `kc_get_theme_version` utility
- display theme version in footer

## Testing
- `php -l utils.php footer.php functions.php`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a654030e8c832899894a38cff270e1