### PR TITLE
feat: add editor preview styles for 3D ring carousel

### DIFF
--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -1,0 +1,30 @@
+/* Editor-only preview for 3D ring carousel (no JS in editor) */
+.block-editor .kc-ring-stage{
+  min-height: 360px;
+  display: grid;
+  place-items: center;
+  background: #f6f8fb;
+  border-radius: 12px;
+  outline: 1px dashed rgba(0,0,0,.08);
+}
+.block-editor .kc-ring{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  justify-content: center;
+  align-items: center;
+  padding: 12px;
+}
+.block-editor .kc-tile{
+  width: 160px;
+  height: 110px;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.05);
+}
+.block-editor .kc-tile img{
+  max-width: 85%;
+  max-height: 75%;
+}

--- a/functions.php
+++ b/functions.php
@@ -51,3 +51,16 @@ add_action( 'enqueue_block_editor_assets', function () {
   }
 });
 /** ---------- END: Kadence Child Pattern Category ---------- */
+
+// Enqueue editor-only styles so the 3D ring carousel previews nicely in the editor
+add_action('enqueue_block_editor_assets', function () {
+  $path = get_stylesheet_directory() . '/assets/css/editor.css';
+  if ( file_exists( $path ) ) {
+    wp_enqueue_style(
+      'kadence-child-editor',
+      get_stylesheet_directory_uri() . '/assets/css/editor.css',
+      [],
+      filemtime( $path )
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add editor-only preview styles for 3D ring carousel
- enqueue editor CSS in block editor

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a65f537f348328a4b3cbc8da4357f3