### PR TITLE
fix(css): force enqueue child styles + carousel overrides

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -64,3 +64,14 @@ add_action('enqueue_block_editor_assets', function () {
     );
   }
 });
+// Ensure child styles load after parent, with cache-busting
+add_action('wp_enqueue_scripts', function () {
+  wp_enqueue_style('kadence-parent', get_template_directory_uri() . '/style.css', [], null);
+  $child_css_path = get_stylesheet_directory() . '/style.css';
+  wp_enqueue_style(
+    'kadence-child',
+    get_stylesheet_uri(),
+    ['kadence-parent'],
+    file_exists($child_css_path) ? filemtime($child_css_path) : null
+  );
+}, 5);

--- a/style.css
+++ b/style.css
@@ -116,3 +116,8 @@
 .kc-tile img { display:block; max-width:120px; max-height:90px; height:auto; object-fit:contain; }
 @keyframes kc-spin { from { transform: translate(-50%,-50%) rotateY(0deg);} to { transform: translate(-50%,-50%) rotateY(-360deg);} }
 /* === END: KC 3D Ring Base (v1) === */
+
+/* === KC override (prove CSS is loading) === */
+.kc-ring-stage{ height:520px !important; perspective:1600px !important; }
+.kc-tile img{ max-width:110px !important; max-height:80px !important; }
+.kc-ring{ animation: kc-spin var(--kc-speed, 28s) linear infinite !important; } 


### PR DESCRIPTION
## Summary
- enqueue parent and child styles with cache-busting
- add KC override CSS to prove child styles load

## Testing
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a67556113c8328aaee9ac86029ed70