### PR TITLE
feat(carousel): color logos + card wrapper + JS spin

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,83 +41,52 @@
 .kc-scroll-cue{ position:absolute; left:50%; bottom:10px; transform:translateX(-50%); font-size:.8rem; letter-spacing:.2em; opacity:.7 }
 @media (max-width: 782px){ .kc-hero-sub{ max-width:100%; } }
 
-.kc-tile{
-  position:absolute; top:50%; left:50%;
-  /* center with classic transform (not the newer translate: property) */
-  /* JS will append additional rotate/translateZ; this base stays compatible */
-  transform: translate(-50%, -50%);
-  transform-style: preserve-3d;
-  width: clamp(120px, 10vw, 160px);
-  height: clamp(70px, 7vw, 110px);
-  display: grid; place-items: center;
-  background:#fff; border-radius:14px;
-  box-shadow:0 10px 24px rgba(0,0,0,.08), inset 0 1px 0 rgba(255,255,255,.8);
-  backface-visibility: hidden;
-}
-.kc-tile img{
-  max-width:85%; max-height:75%;
-  filter:grayscale(100%); opacity:.9; transition:.2s;
-  backface-visibility: hidden;
-}
-.kc-tile:hover img{ filter:none; opacity:1; }
-
-/* ===== 3D Ring Carousel Base Styles (theme) ===== */
-.kc-ring-stage {
+/* === KC 3D Ring (JS-driven) === */
+.kc-ring-stage{
   position: relative;
   width: 100%;
-  height: 460px;             /* taller stage */
-  perspective: 1600px;       /* depth */
+  height: 520px;                 /* front-end verified */
+  perspective: 1600px;
+  perspective-origin: 50% 42%;
   overflow: visible;
 }
-.kc-ring {
+.kc-ring{
   position: absolute;
   top: 50%;
   left: 50%;
   transform-style: preserve-3d;
-  transform: translate(-50%, -50%) rotateY(0deg);
-  animation: kc-spin var(--kc-speed, 28s) linear infinite; /* default slower */
+  /* JS will set: translate(-50%,-50%) rotateX(10deg) rotateY(angle) */
+  will-change: transform;
 }
-.kc-tile {
+.kc-tile{
   position: absolute;
   top: 50%;
   left: 50%;
   transform-style: preserve-3d;
   backface-visibility: hidden;
 }
-.kc-tile img {
+/* Card wrapper the JS will insert (or use if present) */
+.kc-card{
+  width: 160px;
+  height: 110px;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
+  backface-visibility: hidden;
+}
+.kc-card img{
   display: block;
-  max-width: 120px;          /* smaller logos to prevent crowding */
-  max-height: 90px;
+  max-width: 85%;
+  max-height: 75%;
   height: auto;
   object-fit: contain;
+  /* COLOR logos — remove grayscale */
+  filter: none;
+  opacity: 1;
 }
-@keyframes kc-spin {
-  from { transform: translate(-50%, -50%) rotateY(0deg); }
-  to   { transform: translate(-50%, -50%) rotateY(-360deg); }
+@media (max-width: 640px){
+  .kc-ring-stage{ height: 460px; }
+  .kc-card{ width: 140px; height: 96px; }
 }
-
-/* === BEGIN: KC 3D Ring Base (v1) === */
-.kc-ring-stage {
-  position: relative;
-  width: 100%;
-  height: 460px;
-  perspective: 1600px;
-  overflow: visible;
-}
-.kc-ring {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform-style: preserve-3d;
-  transform: translate(-50%, -50%) rotateY(0deg);
-  animation: kc-spin var(--kc-speed, 28s) linear infinite;
-}
-.kc-tile { position:absolute; top:50%; left:50%; transform-style:preserve-3d; backface-visibility:hidden; }
-.kc-tile img { display:block; max-width:120px; max-height:90px; height:auto; object-fit:contain; }
-@keyframes kc-spin { from { transform: translate(-50%,-50%) rotateY(0deg);} to { transform: translate(-50%,-50%) rotateY(-360deg);} }
-/* === END: KC 3D Ring Base (v1) === */
-
-/* === KC override (prove CSS is loading) === */
-.kc-ring-stage{ height:520px !important; perspective:1600px !important; }
-.kc-tile img{ max-width:110px !important; max-height:80px !important; }
-.kc-ring{ animation: kc-spin var(--kc-speed, 28s) linear infinite !important; } 


### PR DESCRIPTION
## Summary
- replace carousel styles with JS-driven 3D ring
- add `.kc-card` wrapper and support for color logos
- drop CSS spin animation in favor of JS control

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a678dcbbd88328806b687ea1130832