### PR TITLE
feat(carousel): RAF spin + auto radius + face camera

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,6 +1,6 @@
 console.log("Kadence Child JS loaded");
 
-// HERO reveal
+// HERO reveal (unchanged)
 (function () {
   const title = document.querySelector('.kc-hero-title');
   if (!title) return;
@@ -8,51 +8,114 @@ console.log("Kadence Child JS loaded");
   obs.observe(title);
 })();
 
-// 3D RING (auto-size + no animation reset)
+// ===== 3D RING — JS-driven rotation with “face camera” cards =====
 (function () {
-  const GAP=28, MIN_RADIUS=360, MAX_RADIUS=700;
-  const face = (tile, theta, r) => {
-    tile.style.transform = `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${r}px) rotateY(${-theta}deg)`;
-    tile.style.transformStyle = 'preserve-3d';
+  const GAP = 28;               // spacing between tiles (px)
+  const MIN_R = 360, MAX_R = 720;
+  const TILT = 10;              // degrees around X axis
+
+  const wrapAsCard = (tile) => {
+    // ensure we have .kc-card wrapper (so we can counter-rotate logos)
+    if (tile.querySelector('.kc-card')) return tile.querySelector('.kc-card');
+    const card = document.createElement('div');
+    card.className = 'kc-card';
+    while (tile.firstChild) card.appendChild(tile.firstChild);
+    tile.appendChild(card);
+    return card;
   };
-  const calcR = (ring) => {
-    const widths = [...ring.querySelectorAll('.kc-tile img')].map(i=>i.getBoundingClientRect().width||110);
-    const total = widths.reduce((a,b)=>a+b,0) + GAP*widths.length;
-    return Math.max(MIN_RADIUS, Math.min(Math.ceil(total/(2*Math.PI)*1.1), MAX_RADIUS));
+
+  const calcRadius = (ring) => {
+    // Use the card widths so spacing matches what the user sees
+    const cards = [...ring.querySelectorAll('.kc-card')];
+    const widths = cards.map(c => c.getBoundingClientRect().width || 140);
+    const total = widths.reduce((a,b)=>a+b,0) + GAP * widths.length;
+    return Math.max(MIN_R, Math.min(Math.ceil(total / (2*Math.PI) * 1.05), MAX_R));
   };
+
   const initRing = (ring, idx) => {
-    const stage = ring.closest('.kc-ring-stage'); if(!stage) return;
-    const tiles = [...ring.querySelectorAll('.kc-tile')]; const N = tiles.length||1;
-    const speed = Number(ring.dataset.speed)||28; ring.style.setProperty('--kc-speed', `${speed}s`);
-    const radius = calcR(ring);
-    tiles.forEach((t,i)=>face(t, (360/N)*i, radius));
-    stage.style.height = Math.max(360, Math.min(520, Math.round(radius*0.85))) + 'px';
-    ring.classList.add('kc-spin'); // keep class; don't zero animation
-    // Drag rotate without removing animation; just pause/play
-    let dragging=false, sx=0, cur=0, start=0;
-    const setRot = deg => { ring.style.transform = `rotateY(${deg}deg)`; cur=deg; };
-    const down = x => { dragging=true; sx=x; start=cur; ring.style.animationPlayState='paused'; };
-    const move = x => { if(!dragging) return; setRot(start - (x - sx)*0.4); };
-    const up   = () => { if(!dragging) return; dragging=false; ring.style.animationPlayState='running'; };
-    stage.addEventListener('mousedown', e=>down(e.clientX));
-   window.addEventListener('mousemove', e=>move(e.clientX));
-    window.addEventListener('mouseup', up);
-    stage.addEventListener('touchstart', e=>down(e.touches[0].clientX), {passive:true});
-    stage.addEventListener('touchmove', e=>move(e.touches[0].clientX), {passive:true});
-    stage.addEventListener('touchend', up);
-    console.log('[kc-ring] initialized', {index: idx, tiles: N, radius, speed});
+    const stage = ring.closest('.kc-ring-stage');
+    if (!stage) return;
+
+    // Prepare tiles + cards
+    const tiles = [...ring.querySelectorAll('.kc-tile')];
+    const cards = tiles.map(wrapAsCard);
+    const N = tiles.length || 1;
+
+    // Timing
+    const speed = Number(ring.dataset.speed) || 24; // seconds per revolution
+    let running = true;
+    let angle = 0;              // current Y rotation in deg
+    let offset = 0;             // user drag offset (deg)
+    let last = performance.now();
+
+    // Compute a safe radius from real sizes
+    const radius = calcRadius(ring);
+    // Stage height scaled to radius
+    stage.style.height = Math.max(380, Math.min(560, Math.round(radius * 0.9))) + 'px';
+
+    // Place tiles around ring (Y), translateZ(radius)
+    tiles.forEach((tile, i) => {
+      const theta = (360 / N) * i;
+      tile.dataset.theta = theta;  // keep for later
+      tile.style.transform = `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${radius}px)`;
+      tile.style.transformStyle = 'preserve-3d';
+    });
+
+    // Controls: pause on hover
+    stage.addEventListener('mouseenter', () => { running = false; });
+    stage.addEventListener('mouseleave', () => { running = true; last = performance.now(); });
+
+    // Controls: drag to scrub
+    let dragging=false, sx=0, start=0;
+    const onDown = x => { dragging=true; sx=x; start=offset; running=false; };
+    const onMove = x => { if(!dragging) return; offset = start - (x - sx) * 0.4; };
+    const onUp   = () => { if(!dragging) return; dragging=false; running=true; last = performance.now(); };
+    stage.addEventListener('mousedown', e=>onDown(e.clientX));
+    window.addEventListener('mousemove', e=>onMove(e.clientX));
+    window.addEventListener('mouseup', onUp);
+    stage.addEventListener('touchstart', e=>onDown(e.touches[0].clientX), {passive:true});
+    stage.addEventListener('touchmove',  e=>onMove(e.touches[0].clientX),  {passive:true});
+    stage.addEventListener('touchend', onUp);
+
+    // RAF loop — rotate ring and counter-rotate cards so logos always face camera
+    const apply = () => {
+      ring.style.transform = `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${angle + offset}deg)`;
+      // counter-rotate each card by the ring angle so it faces camera
+      cards.forEach(card => { card.style.transform = `rotateY(${-(angle + offset)}deg)`; });
+    };
+
+    const tick = (t) => {
+      if (running) {
+        const dt = (t - last) / 1000;  // seconds
+        angle = (angle + (360 / speed) * dt) % 360;
+      }
+      last = t;
+      apply();
+      requestAnimationFrame(tick);
+    };
+
+    // Start
+    apply();
+    requestAnimationFrame(tick);
+    console.log('[kc-ring] initialized', { index: idx, tiles: N, radius, speed });
   };
-  const readyImgs = (root, cb) => {
-    const imgs=[...root.querySelectorAll('img')]; if(!imgs.length) return cb();
-    let left=imgs.length; const done=()=>{ if(--left===0) cb(); };
-    imgs.forEach(img=> img.complete ? done() : img.addEventListener('load', done, {once:true}));
+
+  const ready = (root, cb) => {
+    const imgs = [...root.querySelectorAll('img')];
+    if (!imgs.length) return cb();
+    let left = imgs.length; const done = () => { if(--left===0) cb(); };
+    imgs.forEach(img => img.complete ? done() : img.addEventListener('load', done, {once:true}));
     setTimeout(()=>{ if(left>0) cb(); }, 1500);
   };
+
   const initAll = () => {
-    const rings=[...document.querySelectorAll('.kc-ring')];
+    const rings = [...document.querySelectorAll('.kc-ring')];
     console.log(`[kc-ring] rings found: ${rings.length}`);
-    rings.forEach((r,i)=>readyImgs(r, ()=>initRing(r,i)));
+    rings.forEach((ring, i) => ready(ring, () => initRing(ring, i)));
   };
-  if(document.readyState==='loading'){ document.addEventListener('DOMContentLoaded', ()=>{initAll(); setTimeout(initAll,200);}); }
-  else { initAll(); setTimeout(initAll,200); }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => { initAll(); setTimeout(initAll, 200); });
+  } else { initAll(); setTimeout(initAll, 200); }
 })();
+


### PR DESCRIPTION
## Summary
- Replace carousel JS with requestAnimationFrame rotation and cards that counter-rotate to face the camera.
- Compute ring radius from rendered card widths and adjust stage height.
- Add hover pause and drag-scrub interaction and drop grayscale styling.

## Testing
- `node --check assets/child.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a678ee22f48328af1f3f451a7e2d36