### PR TITLE
fix(carousel): stable 3D ring styles (tilt + cards)

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,52 +41,46 @@
 .kc-scroll-cue{ position:absolute; left:50%; bottom:10px; transform:translateX(-50%); font-size:.8rem; letter-spacing:.2em; opacity:.7 }
 @media (max-width: 782px){ .kc-hero-sub{ max-width:100%; } }
 
-/* === KC 3D Ring (JS-driven) === */
+/* === KC 3D Ring: stable CSS (tilt + cards, no grayscale) === */
 .kc-ring-stage{
   position: relative;
   width: 100%;
-  height: 520px;                 /* front-end verified */
+  height: 520px;
   perspective: 1600px;
   perspective-origin: 50% 42%;
   overflow: visible;
 }
 .kc-ring{
   position: absolute;
-  top: 50%;
-  left: 50%;
+  top: 50%; left: 50%;
   transform-style: preserve-3d;
-  /* JS will set: translate(-50%,-50%) rotateX(10deg) rotateY(angle) */
+  transform: translate(-50%,-50%) rotateX(10deg) rotateY(0deg);
+  animation: kc-spin var(--kc-speed, 24s) linear infinite;
   will-change: transform;
 }
+@keyframes kc-spin{
+  from { transform: translate(-50%,-50%) rotateX(10deg) rotateY(0deg); }
+  to   { transform: translate(-50%,-50%) rotateX(10deg) rotateY(-360deg); }
+}
 .kc-tile{
-  position: absolute;
-  top: 50%;
-  left: 50%;
+  position:absolute; top:50%; left:50%;
   transform-style: preserve-3d;
   backface-visibility: hidden;
+  /* JS will set rotateY(theta) translateZ(radius) */
+  transform: translate(-50%,-50%);
 }
-/* Card wrapper the JS will insert (or use if present) */
 .kc-card{
-  width: 160px;
-  height: 110px;
-  display: grid;
-  place-items: center;
-  background: #fff;
-  border-radius: 16px;
+  width: 160px; height: 110px;
+  display:grid; place-items:center;
+  background:#fff; border-radius:16px;
   box-shadow: 0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
   backface-visibility: hidden;
 }
 .kc-card img{
-  display: block;
-  max-width: 85%;
-  max-height: 75%;
-  height: auto;
-  object-fit: contain;
-  /* COLOR logos — remove grayscale */
-  filter: none;
-  opacity: 1;
+  display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain;
+  filter:none; opacity:1; /* color logos */
 }
 @media (max-width: 640px){
-  .kc-ring-stage{ height: 460px; }
-  .kc-card{ width: 140px; height: 96px; }
+  .kc-ring-stage{ height:460px; }
+  .kc-card{ width:140px; height:96px; }
 }


### PR DESCRIPTION
## Summary
- swap carousel ring styles for stable 3D tilt + spin
- ensure cards render in color with shadow and sizing tweaks
## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e47777c8328af125ee3f97a089b