### PR TITLE
fix(carousel): true 360 layout + pause/drag (CSS spin)

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,4 +1,3 @@
-// Smoke test
 console.log("Kadence Child JS loaded");
 
 // HERO reveal (unchanged)
@@ -11,14 +10,11 @@ console.log("Kadence Child JS loaded");
   obs.observe(title);
 })();
 
-// ===== 3D RING — true circle, per-tile face-camera, auto radius =====
+// ===== Stable 3D ring (CSS spin; JS just lays out + controls) =====
 (function () {
-  const GAP   = 28;               // px spacing between cards
-  const TILT  = 12;               // deg X-tilt for depth
-  const MIN_R = 300, MAX_R = 640; // clamp radius
+  const GAP=24, MIN_R=280, MAX_R=620, TILT=10; // tweakables
 
-  // Ensure each .kc-tile contains a .kc-card wrapper (for shadows/sizing)
-  const wrapAsCard = (tile) => {
+  const ensureCard = (tile) => {
     let card = tile.querySelector('.kc-card');
     if (!card) {
       card = document.createElement('div');
@@ -29,91 +25,60 @@ console.log("Kadence Child JS loaded");
     return card;
   };
 
-  // Compute a radius from real rendered widths, then tighten it a bit
-  const calcRadius = (ring) => {
+  const radiusFromWidths = (ring) => {
     const cards = [...ring.querySelectorAll('.kc-card')];
     const widths = cards.map(c => c.getBoundingClientRect().width || 140);
-    const total  = widths.reduce((a,b)=>a+b,0) + GAP * widths.length;
-    const rawR   = total / (2 * Math.PI);  // circumference = 2πr
-    const tightR = rawR * 0.8;             // tighten so we see a fuller circle
-    return Math.max(MIN_R, Math.min(Math.ceil(tightR), MAX_R));
+    const circ   = widths.reduce((a,b)=>a+b,0) + GAP*widths.length;
+    // tighten slightly so the ring is a full circle, not a shallow arc
+    const r = (circ / (2*Math.PI)) * 0.85;
+    return Math.max(MIN_R, Math.min(Math.round(r), MAX_R));
   };
 
-  const initRing = (ring, idx) => {
-    const stage = ring.closest('.kc-ring-stage');
-    if (!stage) return;
-
-    // Prepare tiles/cards
+  const layout = (ring) => {
     const tiles = [...ring.querySelectorAll('.kc-tile')];
-    const cards = tiles.map(wrapAsCard);
-    const N     = tiles.length || 1;
-
-    // Timing
-    const speed = Number(ring.dataset.speed) || 24; // seconds per revolution
-    let running = true;
-    let angle   = 0;   // global Y angle
-    let offset  = 0;   // user drag offset
-    let last    = performance.now();
-
-    // Radius + stage height
-    const radius = calcRadius(ring);
-    stage.style.height = Math.max(380, Math.min(560, Math.round(radius * 0.9))) + 'px';
-
-    // Place tiles evenly around the ring and store theta on each tile
+    tiles.forEach(ensureCard);
+    const N = tiles.length || 1;
+    const radius = radiusFromWidths(ring);
+    // distribute evenly around Y
     tiles.forEach((tile, i) => {
       const theta = (360 / N) * i;
-      tile.dataset.theta = theta;
-      tile.style.transformStyle = 'preserve-3d';
-      // true circular layout (no extra tilts here): each tile sits on the ring
       tile.style.transform = `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${radius}px)`;
     });
-
-    // Interaction: pause on hover
-    stage.addEventListener('mouseenter', () => { running = false; });
-    stage.addEventListener('mouseleave', () => { running = true; last = performance.now(); });
-
-    // Interaction: drag to scrub (mouse + touch)
-    let dragging=false, sx=0, start=0;
-    const onDown = x => { dragging=true; sx=x; start=offset; running=false; };
-    const onMove = x => { if(!dragging) return; offset = start - (x - sx) * 0.4; };
-    const onUp   = () => { if(!dragging) return; dragging=false; running=true; last=performance.now(); };
-    stage.addEventListener('mousedown', e=>onDown(e.clientX));
-    window.addEventListener('mousemove', e=>onMove(e.clientX));
-    window.addEventListener('mouseup', onUp);
-    stage.addEventListener('touchstart', e=>onDown(e.touches[0].clientX), {passive:true});
-    stage.addEventListener('touchmove',  e=>onMove(e.touches[0].clientX),  {passive:true});
-    stage.addEventListener('touchend', onUp);
-
-    // Render: rotate the ring, counter-rotate each CARD by (angle + theta)
-    const apply = () => {
-      ring.style.transform = `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${angle + offset}deg)`;
-      cards.forEach(card => {
-        const theta = Number(card.parentNode.dataset.theta || 0);
-        // Counter the ring rotation + tile's own theta so faces camera
-        card.style.transform = `rotateY(${-(angle + offset + theta)}deg)`;
-      });
-    };
-
-    const tick = (t) => {
-      if (running) {
-        const dt = (t - last) / 1000;           // seconds since last frame
-        angle = (angle + (360 / speed) * dt) % 360;
-      }
-      last = t;
-      apply();
-      requestAnimationFrame(tick);
-    };
-
-    apply();
-    requestAnimationFrame(tick);
-    console.log('[kc-ring] initialized', { index: idx, tiles: N, radius, speed });
+    // set stage height to match radius / tilt
+    const stage = ring.closest('.kc-ring-stage');
+    if (stage) stage.style.height = Math.max(380, Math.min(560, Math.round(radius*0.9))) + 'px';
+    return { radius, N };
   };
 
-  // Wait for images so sizes are real before layout
+  const addControls = (ring) => {
+    const stage = ring.closest('.kc-ring-stage');
+    if (!stage) return;
+    // pause on hover (CSS animation play state)
+    stage.addEventListener('mouseenter', ()=>{ ring.style.animationPlayState='paused'; });
+    stage.addEventListener('mouseleave', ()=>{ ring.style.animationPlayState='running'; });
+    // drag scrub by adjusting --kc-speed sign via inline rotation offset
+    let dragging=false, sx=0, start=0;
+    const getRot = () => {
+      const m = /rotateY\((-?\d+(?:\.\d+)?)deg\)/.exec(getComputedStyle(ring).transform);
+      return 0; // we don’t read; we just apply offset directly
+    };
+    let offset=0;
+    const apply = ()=> ring.style.transform = `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${offset}deg)`;
+    const down = x => { dragging=true; sx=x; ring.style.animationPlayState='paused'; };
+    const move = x => { if(!dragging) return; offset += (x - sx) * -0.3; sx=x; apply(); };
+    const up   = () => { if(!dragging) return; dragging=false; ring.style.animationPlayState='running'; };
+    stage.addEventListener('mousedown', e=>down(e.clientX));
+    window.addEventListener('mousemove', e=>move(e.clientX));
+    window.addEventListener('mouseup', up);
+    stage.addEventListener('touchstart', e=>down(e.touches[0].clientX), {passive:true});
+    stage.addEventListener('touchmove',  e=>move(e.touches[0].clientX), {passive:true});
+    stage.addEventListener('touchend', up);
+  };
+
   const ready = (root, cb) => {
     const imgs = [...root.querySelectorAll('img')];
     if (!imgs.length) return cb();
-    let left = imgs.length; const done = () => { if(--left===0) cb(); };
+    let left=imgs.length; const done=()=>{ if(--left===0) cb(); };
     imgs.forEach(img => img.complete ? done() : img.addEventListener('load', done, {once:true}));
     setTimeout(()=>{ if(left>0) cb(); }, 1500);
   };
@@ -121,10 +86,15 @@ console.log("Kadence Child JS loaded");
   const initAll = () => {
     const rings = [...document.querySelectorAll('.kc-ring')];
     console.log(`[kc-ring] rings found: ${rings.length}`);
-    rings.forEach((ring, i) => ready(ring, () => initRing(ring, i)));
+    rings.forEach(ring => ready(ring, () => {
+      const info = layout(ring);
+      addControls(ring);
+      console.log('[kc-ring] laid out', info);
+    }));
   };
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => { initAll(); setTimeout(initAll, 200); });
-  } else { initAll(); setTimeout(initAll, 200); }
+  if (document.readyState==='loading'){
+    document.addEventListener('DOMContentLoaded', ()=>{ initAll(); setTimeout(initAll,200); });
+  } else { initAll(); setTimeout(initAll,200); }
 })();
+


### PR DESCRIPTION
## Summary
- replace carousel JS with simple initializer that wraps tiles in `.kc-card`, computes radius, and lays out a full 360° ring
- add hover-pause and drag scrubbing without breaking CSS spin

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a67e61339883288ceb1c5791cfd2e1