### PR TITLE
fix(carousel/css): restore animation + enforce 3D ring styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -84,3 +84,34 @@
   .kc-ring-stage{ height:460px; }
   .kc-card{ width:140px; height:96px; }
 }
+/* === ENFORCE KC RING BASE === */
+.kc-ring-stage{
+  position:relative; width:100%;
+  height: 520px; perspective:1600px; perspective-origin:50% 42%;
+  overflow: visible;
+}
+.kc-ring{
+  position:absolute; top:50%; left:50%;
+  transform-style:preserve-3d;
+  transform: translate(-50%,-50%) rotateX(10deg) rotateY(0deg) !important;
+  animation: kc-spin var(--kc-speed, 24s) linear infinite !important;
+  will-change: transform;
+}
+@keyframes kc-spin{
+  from { transform: translate(-50%,-50%) rotateX(10deg) rotateY(0deg); }
+  to   { transform: translate(-50%,-50%) rotateX(10deg) rotateY(-360deg); }
+}
+.kc-tile{
+  position:absolute; top:50%; left:50%;
+  transform-style:preserve-3d; backface-visibility:hidden;
+  /* JS will set rotateY(theta) translateZ(radius) */
+  transform: translate(-50%,-50%);
+}
+.kc-card{
+  width:160px; height:110px; display:grid; place-items:center;
+  background:#fff; border-radius:16px;
+  box-shadow:0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
+  backface-visibility: hidden;
+}
+.kc-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; filter:none; }
+@media (max-width:640px){ .kc-ring-stage{ height:460px; } .kc-card{ width:140px; height:96px; } }


### PR DESCRIPTION
## Summary
- restore animation on 3D ring
- enforce base CSS for ring and cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6818512d48328ab33f690f965aa67