### PR TITLE
feat(carousel): reset to es-* namespaced, js-rotating, face-camera ring

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -9,199 +9,104 @@ console.log("Kadence Child JS loaded");
   }), {threshold:.4});
   obs.observe(title);
 })();
-
-// ===== 3D RING — FINAL BUNDLE =====
-(function () {
-  const GAP = 28, TIGHT = 0.72, MIN_R = 260, MAX_R = 640, TILT = 10;
+// ===== ES CAROUSEL (clean reset) =====
+(function(){
+  const GAP=24, TIGHT=0.72, MIN_R=260, MAX_R=620, TILT=8, SPEED=28; // sec/rev
+  const $ = (s, r=document) => r.querySelector(s);
+  const $$ = (s, r=document) => [...r.querySelectorAll(s)];
 
   const ensureCard = (tile) => {
-    let card = tile.querySelector('.kc-card');
+    let card = tile.querySelector('.es-card');
     if (!card) {
-      card = document.createElement('div');
-      card.className = 'kc-card';
+      card = document.createElement('div'); card.className = 'es-card';
       while (tile.firstChild) card.appendChild(tile.firstChild);
       tile.appendChild(card);
     }
     return card;
   };
 
-  const calcRadius = (ring) => {
-    const cards = [...ring.querySelectorAll('.kc-card')];
+  const radiusFrom = (ring) => {
+    const cards = $$('.es-card', ring);
     const widths = cards.map(c => c.getBoundingClientRect().width || 140);
-    const circ   = widths.reduce((a,b)=>a+b,0) + GAP*widths.length;
-    const r      = (circ / (2*Math.PI)) * TIGHT;
+    const circ = widths.reduce((a,b)=>a+b,0) + GAP*widths.length;
+    const r = (circ/(2*Math.PI))*TIGHT;
     return Math.max(MIN_R, Math.min(Math.round(r), MAX_R));
-  };
-
-  const layoutRing = (ring) => {
-    const stage = ring.closest('.kc-ring-stage');
-    const tiles = [...ring.querySelectorAll('.kc-tile')];
-    if (!tiles.length) return;
-    tiles.forEach(ensureCard);
-    const N = tiles.length;
-    const radius = calcRadius(ring);
-    tiles.forEach((tile, i) => {
-      const theta = (360 / N) * i;
-      tile.style.transform =
-        `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${radius}px)`;
-    });
-    if (stage) {
-      stage.style.height = Math.max(380, Math.min(560, Math.round(radius*0.9))) + 'px';
-    }
-    ring.style.animationPlayState = 'running';
-    stage?.addEventListener('mouseenter', ()=> ring.style.animationPlayState = 'paused');
-    stage?.addEventListener('mouseleave', ()=> ring.style.animationPlayState = 'running');
-
-    // Drag scrub: temporarily stop CSS animation and rotate ring inline
-    let dragging=false, sx=0, base=0;
-    const apply = (deg) => ring.style.transform =
-      `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${deg}deg)`;
-    const down = x => { dragging=true; sx=x; base=0; ring.style.animation='none'; };
-    const move = x => { if(!dragging) return; const d = (x - sx) * -0.35; apply(base + d); };
-    const up   = () => { if(!dragging) return; dragging=false; ring.style.animation=''; };
-    stage?.addEventListener('mousedown', e=>down(e.clientX));
-    window.addEventListener('mousemove', e=>move(e.clientX));
-    window.addEventListener('mouseup', up);
-    stage?.addEventListener('touchstart', e=>down(e.touches[0].clientX), {passive:true});
-    stage?.addEventListener('touchmove',  e=>move(e.touches[0].clientX),  {passive:true});
-    stage?.addEventListener('touchend', up);
-
-    console.log('[kc-ring] laid out', {tiles: N, radius});
-  };
-
-  const ready = (root, cb) => {
-    const imgs = [...root.querySelectorAll('img')];
-    if (!imgs.length) return cb();
-    let left = imgs.length; const done = ()=>{ if(--left===0) cb(); };
-    imgs.forEach(img => img.complete ? done() : img.addEventListener('load', done, {once:true}));
-    setTimeout(()=>{ if(left>0) cb(); }, 1200);
-  };
-
-  const init = () => {
-    const rings = [...document.querySelectorAll('.kc-ring')];
-    if (!rings.length) return;
-    rings.forEach(ring => ready(ring, ()=> layoutRing(ring)));
-  };
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
-
-  // short verify helper
-  window.kcRingVerify = () => {
-    const rings = [...document.querySelectorAll('.kc-ring')];
-    return rings.map(r => ({ tiles: r.querySelectorAll('.kc-tile').length }));
-  };
-})();
-
-// ===== 3D RING — FINAL BUNDLE (JS, face-camera) =====
-(function () {
-  const GAP   = 24;     // spacing between cards
-  const TIGHT = 0.72;   // tighter ring → more circle visible (0.68 tighter, 0.80 looser)
-  const MIN_R = 260, MAX_R = 620;
-  const TILT  = 8;      // must match CSS rotateX
-  const SPEED = 28;     // seconds per revolution (fallback)
-
-  const ensureCard = (tile) => {
-    let card = tile.querySelector('.kc-card');
-    if (!card) {
-      card = document.createElement('div'); card.className = 'kc-card';
-      while (tile.firstChild) card.appendChild(tile.firstChild);
-      tile.appendChild(card);
-    }
-    return card;
-  };
-
-  const calcRadius = (ring) => {
-    const cards = [...ring.querySelectorAll('.kc-card')];
-    const widths = cards.map(c => c.getBoundingClientRect().width || 140);
-    const circ   = widths.reduce((a,b)=>a+b,0) + GAP*widths.length;
-    const r      = (circ / (2*Math.PI)) * TIGHT;
-    return Math.max(MIN_R, Math.min(Math.round(r), MAX_R));
-  };
-
-  const layoutRing = (ring) => {
-    const stage = ring.closest('.kc-ring-stage');
-    const tiles = [...ring.querySelectorAll('.kc-tile')];
-    if (!tiles.length) return;
-    tiles.forEach(ensureCard);
-    const N = tiles.length;
-    const radius = calcRadius(ring);
-
-    // Distribute evenly + store theta on each tile
-    tiles.forEach((tile, i) => {
-      const theta = (360 / N) * i;
-      tile.dataset.theta = theta;
-      tile.style.transform =
-        `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${radius}px)`;
-    });
-
-    // Stage height based on radius
-    if (stage) stage.style.height = Math.max(420, Math.min(600, Math.round(radius*0.95))) + 'px';
-
-    // --- JS ANIMATION (face camera) ---
-    // Kill CSS animation so we control the angle
-    ring.style.animation = 'none';
-
-    let running = true;
-    let angle   = 0; // current Y angle
-    let last    = performance.now();
-    const speed = Number(ring.dataset.speed) || SPEED; // seconds per revolution
-
-    const cards = tiles.map(t => t.querySelector('.kc-card'));
-
-    const render = (t) => {
-      if (running) {
-        const dt = (t - last) / 1000;
-        angle = (angle + (360/speed) * dt) % 360;
-      }
-      last = t;
-
-      ring.style.transform =
-        `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${angle}deg)`;
-
-      // Counter-rotate each card so logos always face the viewer
-      tiles.forEach((tile, i) => {
-        const theta = Number(tile.dataset.theta) || 0;
-        const card  = cards[i];
-        if (card) card.style.transform = `rotateY(${-(angle + theta)}deg)`;
-      });
-
-      requestAnimationFrame(render);
-    };
-    requestAnimationFrame(render);
-
-    // Hover pause/resume
-   stage?.addEventListener('mouseenter', ()=> running = false);
-    stage?.addEventListener('mouseleave', ()=> { running = true; last = performance.now(); });
-
-    // Drag scrub (pause while dragging, set angle directly)
-    let dragging=false, sx=0, start=0;
-    const down = (x)=>{ dragging=true; sx=x; start=angle; running=false; };
-    const move = (x)=>{ if(!dragging) return; angle = start - (x - sx)*0.35; };
-    const up   = ()=>{ if(!dragging) return; dragging=false; running=true; last = performance.now(); };
-    stage?.addEventListener('mousedown', e=>down(e.clientX));
-    window.addEventListener('mousemove', e=>move(e.clientX));
-    window.addEventListener('mouseup', up);
-    stage?.addEventListener('touchstart', e=>down(e.touches[0].clientX), {passive:true});
-    stage?.addEventListener('touchmove',  e=>move(e.touches[0].clientX),  {passive:true});
-    stage?.addEventListener('touchend', up);
-
-    console.log('[kc-ring] js-spin face-camera on', { tiles: N, radius, speed });
   };
 
   const imagesReady = (root, cb) => {
-    const imgs = [...root.querySelectorAll('img')];
+    const imgs = $$('img', root);
     if (!imgs.length) return cb();
-    let left = imgs.length; const done = ()=>{ if(--left===0) cb(); };
+    let left = imgs.length; const done=()=>{ if(--left===0) cb(); };
     imgs.forEach(img => img.complete ? done() : img.addEventListener('load', done, {once:true}));
     setTimeout(()=>{ if(left>0) cb(); }, 1200);
   };
 
-  const init = () => {
-    const rings = [...document.querySelectorAll('.kc-ring')];
-    rings.forEach(ring => imagesReady(ring, ()=> layoutRing(ring)));
+  const initOne = (ring) => {
+    const stage = ring.closest('.es-stage');
+    const tiles = $$('.es-tile', ring);
+    if (!tiles.length) return;
+
+    // set up cards and distribute around ring
+    tiles.forEach(ensureCard);
+    const N = tiles.length;
+    const radius = radiusFrom(ring);
+
+    tiles.forEach((tile,i)=>{
+      const theta = (360/N)*i;
+      tile.dataset.theta = theta;
+      tile.style.transform = `translate(-50%,-50%) rotateY(${theta}deg) translateZ(${radius}px)`;
+    });
+
+    if (stage) stage.style.height = Math.max(420, Math.min(600, Math.round(radius*0.95))) + 'px';
+
+    // JS rotation + face-camera cards
+    let running = true, angle = 0, last = performance.now();
+    const cards = tiles.map(t => t.querySelector('.es-card'));
+    const step = (t) => {
+      const dt = (t - last) / 1000; last = t;
+      if (running) angle = (angle + (360/SPEED)*dt) % 360;
+
+      ring.style.transform = `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${angle}deg)`;
+
+      // face the camera: rotate card opposite of ring+its tile angle
+      tiles.forEach((tile, idx) => {
+        const theta = Number(tile.dataset.theta) || 0;
+        const card = cards[idx];
+        if (card) card.style.transform = `rotateY(${-(angle + theta)}deg)`;
+      });
+
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+
+    // interactions
+    stage?.addEventListener('mouseenter', ()=> running=false);
+    stage?.addEventListener('mouseleave', ()=> { running=true; last=performance.now(); });
+
+    let dragging=false, sx=0, start=0;
+    const down = x => { dragging=true; sx=x; start=angle; running=false; };
+    const move = x => { if (!dragging) return; angle = start - (x - sx)*0.35; };
+    const up   = () => { if (!dragging) return; dragging=false; running=true; last=performance.now(); };
+
+    stage?.addEventListener('mousedown', e=>down(e.clientX));
+    window.addEventListener('mousemove', e=>move(e.clientX));
+    window.addEventListener('mouseup', up);
+
+    stage?.addEventListener('touchstart', e=>down(e.touches[0].clientX), {passive:true});
+    stage?.addEventListener('touchmove',  e=>move(e.touches[0].clientX),  {passive:true});
+    stage?.addEventListener('touchend', up);
+
+    console.log('[es-carousel] ready', {tiles:N, radius});
   };
-  const debounce = (fn,ms)=>{let t;return()=>{clearTimeout(t);t=setTimeout(fn,ms)}};
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init); else init();
-  window.addEventListener('resize', debounce(init, 250));
+
+  const initAll = () => {
+    $$('.es-ring').forEach(ring => imagesReady(ring, ()=>initOne(ring)));
+  };
+  const debounce=(fn,ms)=>{let t;return()=>{clearTimeout(t);t=setTimeout(fn,ms)}};
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAll);
+  } else { initAll(); }
+
+  window.addEventListener('resize', debounce(initAll, 250));
 })();
-
-

--- a/style.css
+++ b/style.css
@@ -40,120 +40,34 @@
 /* Scroll cue */
 .kc-scroll-cue{ position:absolute; left:50%; bottom:10px; transform:translateX(-50%); font-size:.8rem; letter-spacing:.2em; opacity:.7 }
 @media (max-width: 782px){ .kc-hero-sub{ max-width:100%; } }
-
-/* === KC 3D Ring: stable CSS (tilt + cards, no grayscale) === */
-.kc-ring-stage{
-  position: relative;
-  width: 100%;
-  height: 560px;
-  perspective: 1600px;
-  perspective-origin: 50% 42%;
-  overflow: visible;
-}
-.kc-ring{
-  position: absolute;
-  top: 50%; left: 50%;
-  transform-style: preserve-3d;
-  transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg);
-  animation: kc-spin var(--kc-speed, 24s) linear infinite;
-  will-change: transform;
-}
-@keyframes kc-spin{
-  from { transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg); }
-  to   { transform: translate(-50%,-50%) rotateX(8deg) rotateY(-360deg); }
-}
-.kc-tile{
-  position:absolute; top:50%; left:50%;
-  transform-style: preserve-3d;
-  backface-visibility: hidden;
-  /* JS will set rotateY(theta) translateZ(radius) */
-  transform: translate(-50%,-50%);
-}
-.kc-card{
-  width: 160px; height: 110px;
-  display:grid; place-items:center;
-  background:#fff; border-radius:16px;
-  box-shadow: 0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
-  backface-visibility: hidden;
-}
-.kc-card img{
-  display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain;
-  filter:none; opacity:1; /* color logos */
-}
-@media (max-width: 640px){
-  .kc-ring-stage{ height:460px; }
-  .kc-card{ width:140px; height:96px; }
-}
-/* === ENFORCE KC RING BASE === */
-.kc-ring-stage{
+/* ===== ES CAROUSEL (namespaced, clean) ===== */
+.es-stage{
   position:relative; width:100%;
-  height: 560px; perspective:1600px; perspective-origin:50% 42%;
-  overflow: visible;
+  height:560px; perspective:1600px; perspective-origin:50% 42%;
+  overflow:visible;
 }
-.kc-ring{
+.es-ring{
   position:absolute; top:50%; left:50%;
   transform-style:preserve-3d;
-  transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg) !important;
-  animation: kc-spin var(--kc-speed, 24s) linear infinite !important;
-  will-change: transform;
+  /* JS sets rotateY each frame; keep a stable base tilt only */
+  transform:translate(-50%,-50%) rotateX(8deg) rotateY(0deg);
+  will-change:transform;
 }
-@keyframes kc-spin{
-  from { transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg); }
-  to   { transform: translate(-50%,-50%) rotateX(8deg) rotateY(-360deg); }
-}
-.kc-tile{
+.es-tile{
   position:absolute; top:50%; left:50%;
   transform-style:preserve-3d; backface-visibility:hidden;
-  /* JS will set rotateY(theta) translateZ(radius) */
-  transform: translate(-50%,-50%);
+  transform:translate(-50%,-50%); /* JS adds rotateY(theta) translateZ(r) */
 }
-.kc-card{
+.es-card{
   width:160px; height:110px; display:grid; place-items:center;
   background:#fff; border-radius:16px;
   box-shadow:0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
-  backface-visibility: hidden;
+  backface-visibility:hidden;
+  /* JS sets rotateY(-currentAngle - theta) so faces viewer */
 }
-.kc-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; filter:none; }
-@media (max-width:640px){ .kc-ring-stage{ height:460px; } .kc-card{ width:140px; height:96px; } }
+.es-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; }
 
-/* ===== 3D RING — FINAL BUNDLE (CSS) ===== */
-.kc-ring-stage{
-  position: relative;
-  width: 100%;
-  height: 560px;                 /* a bit more room */
-  perspective: 1600px;
-  perspective-origin: 50% 42%;
-  overflow: visible;
-}
-.kc-ring{
-  position: absolute;
-  top: 50%; left: 50%;
-  transform-style: preserve-3d;
-  transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg) !important;
-  animation: kc-spin var(--kc-speed, 28s) linear infinite !important;
-  will-change: transform;
-}
-@keyframes kc-spin{
-  from { transform: translate(-50%,-50%) rotateX(8deg) rotateY(0deg); }
-  to   { transform: translate(-50%,-50%) rotateX(8deg) rotateY(-360deg); }
-}
-.kc-tile{
-  position: absolute; top: 50%; left: 50%;
-  transform-style: preserve-3d; backface-visibility: hidden;
-  transform: translate(-50%,-50%); /* JS will set rotateY(...) translateZ(...) */
-}
-.kc-card{
-  width: 160px; height: 110px;    /* change here to scale tiles */
-  display: grid; place-items: center;
-  background: #fff; border-radius: 16px;
-  box-shadow: 0 18px 40px rgba(0,0,0,.10), 0 6px 16px rgba(0,0,0,.06);
-  backface-visibility: hidden;
-}
-.kc-card img{
-  display: block; max-width: 85%; max-height: 75%;
-  height: auto; object-fit: contain; filter: none; opacity: 1;
-}
-@media (max-width: 640px){
-  .kc-ring-stage{ height: 500px; }
-  .kc-card{ width: 140px; height: 96px; }
+@media (max-width:640px){
+  .es-stage{ height:500px; }
+  .es-card{ width:140px; height:96px; }
 }


### PR DESCRIPTION
## Summary
- replace old KC ring with ES-namespaced carousel styles
- add ES carousel JS to dynamically size, rotate, and face tiles toward the camera

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a68da3cdb883289de317f9c05e881b