### PR TITLE
feat: allow carousel dataset overrides

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -46,10 +46,14 @@ console.log("Kadence Child JS loaded");
     const tiles = $$('.es-tile', ring);
     if (!tiles.length) return;
 
+    // dataset overrides
+    const speed = Number(ring.dataset.speed) || SPEED;
+    const tilt = ring.dataset.tilt ? Number(ring.dataset.tilt) : TILT;
+    const radius = ring.dataset.radius ? Number(ring.dataset.radius) : radiusFrom(ring);
+
     // set up cards and distribute around ring
     tiles.forEach(ensureCard);
     const N = tiles.length;
-    const radius = radiusFrom(ring);
 
     tiles.forEach((tile,i)=>{
       const theta = (360/N)*i;
@@ -64,9 +68,9 @@ console.log("Kadence Child JS loaded");
     const cards = tiles.map(t => t.querySelector('.es-card'));
     const step = (t) => {
       const dt = (t - last) / 1000; last = t;
-      if (running) angle = (angle + (360/SPEED)*dt) % 360;
+      if (running) angle = (angle + (360/speed)*dt) % 360;
 
-      ring.style.transform = `translate(-50%,-50%) rotateX(${TILT}deg) rotateY(${angle}deg)`;
+      ring.style.transform = `translate(-50%,-50%) rotateX(${tilt}deg) rotateY(${angle}deg)`;
 
       // face the camera: rotate card opposite of ring+its tile angle
       tiles.forEach((tile, idx) => {

--- a/patterns/carousel-3d-ring.php
+++ b/patterns/carousel-3d-ring.php
@@ -4,13 +4,18 @@
  * Slug: kadence-child/carousel-3d-ring
  * Categories: kadence-child
  * Description: 3D rotating ring of logos with autoplay and hover pause.
+ *
+ * Data attributes on <div class="es-ring">:
+ * - data-speed  : seconds per revolution (defaults to 28)
+ * - data-radius : ring radius in pixels (auto if omitted)
+ * - data-tilt   : tilt angle in degrees (defaults to 8)
  */
 ?>
 <!-- wp:group {"align":"full","className":"kc-ring-wrap","style":{"spacing":{"padding":{"top":"36px","bottom":"36px"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
 <div class="wp-block-group alignfull kc-ring-wrap">
   <!-- wp:html -->
   <div class="es-stage">
-    <div class="es-ring" data-radius="560" data-speed="30">
+    <div class="es-ring" data-radius="560" data-speed="30" data-tilt="8">
       <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Wilsonart-01.png" alt="Wilsonart"></div>
       <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vicostone-01.png" alt="Vicostone"></div>
       <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Viatera-01.png" alt="Viatera"></div>


### PR DESCRIPTION
## Summary
- allow es-ring to accept data-speed, data-radius, and data-tilt overrides
- document available data attributes for 3D ring pattern

## Testing
- `npm test` (fails: Could not read package.json)
- `php -l patterns/carousel-3d-ring.php`
- `node --check assets/child.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7ae6af72883289073bcb40ad99732