### PR TITLE
Add no-js fallback for ES carousel

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,5 +1,15 @@
 console.log("Kadence Child JS loaded");
 
+// Remove the no-js class once JS is running
+(function(){
+  const remove = () => document.body.classList.remove('no-js');
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', remove);
+  } else {
+    remove();
+  }
+})();
+
 // HERO reveal (unchanged)
 (function () {
   const title = document.querySelector('.kc-hero-title');

--- a/functions.php
+++ b/functions.php
@@ -75,3 +75,9 @@ add_action('wp_enqueue_scripts', function () {
     file_exists($child_css_path) ? filemtime($child_css_path) : null
   );
 }, 5);
+
+// Add a no-js class so we can style JS fallbacks
+add_filter( 'body_class', function ( $classes ) {
+  $classes[] = 'no-js';
+  return $classes;
+} );

--- a/style.css
+++ b/style.css
@@ -72,7 +72,7 @@
   .es-card{ width:140px; height:96px; }
 }
 
-/* No-JS fallback for ES carousel */
+/* No-JS fallback for ES carousel: remove 3D transforms and absolute positioning */
 .no-js .es-stage{
   height:auto;
   perspective:none;

--- a/style.css
+++ b/style.css
@@ -71,3 +71,21 @@
   .es-stage{ height:500px; }
   .es-card{ width:140px; height:96px; }
 }
+
+/* No-JS fallback for ES carousel */
+.no-js .es-stage{
+  height:auto;
+  perspective:none;
+}
+.no-js .es-ring{
+  position:static;
+  transform:none;
+  display:flex;
+  flex-wrap:wrap;
+  gap:24px;
+  justify-content:center;
+}
+.no-js .es-tile{
+  position:static;
+  transform:none;
+}


### PR DESCRIPTION
## Summary
- Add `no-js` class to `<body>` via filter for graceful degradation
- Remove `no-js` class in child JS once scripts load
- Provide flexbox-based layout for `.es-tile` when JavaScript is disabled

## Testing
- `php -l functions.php`
- `node --check assets/child.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7ae7c7a548328ae236dfe861f6cf6