### PR TITLE
Respect reduced motion preference and add keyboard control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # kadence-child
+
+Child theme playground.
+
+## Features
+- 3D logo carousel respects reduced-motion preference and supports keyboard navigation.

--- a/patterns/carousel-3d-ring.php
+++ b/patterns/carousel-3d-ring.php
@@ -9,7 +9,7 @@
 <!-- wp:group {"align":"full","className":"kc-ring-wrap","style":{"spacing":{"padding":{"top":"36px","bottom":"36px"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
 <div class="wp-block-group alignfull kc-ring-wrap">
   <!-- wp:html -->
-  <div class="es-stage">
+    <div class="es-stage" tabindex="0" role="region" aria-label="Logo carousel">
     <div class="es-ring" data-radius="560" data-speed="30">
       <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Wilsonart-01.png" alt="Wilsonart"></div>
       <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vicostone-01.png" alt="Vicostone"></div>


### PR DESCRIPTION
## Summary
- Respect `prefers-reduced-motion` so carousel only auto-rotates after interaction
- Make carousel focusable with `tabindex`, `role`, and `aria-label`
- Allow keyboard users to rotate carousel via left/right arrows
- Document carousel features in README

## Testing
- `node --check assets/child.js`
- `php -l patterns/carousel-3d-ring.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ae78df4083288f77d1ec58dacf0a