### PR TITLE
Add JS detection and no-js fallbacks

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,3 +1,4 @@
+document.body.classList.remove('no-js');
 console.log("Kadence Child JS loaded");
 
 // HERO reveal (unchanged)

--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,13 @@ require_once __DIR__ . '/utils.php';
  * Kadence Child – enqueue styles & JS
  */
 
+add_filter( 'body_class', function ( $classes ) {
+  if ( ! in_array( 'no-js', $classes, true ) ) {
+    $classes[] = 'no-js';
+  }
+  return $classes;
+} );
+
 add_action('wp_enqueue_scripts', function () {
   // Parent theme CSS
   wp_enqueue_style(

--- a/style.css
+++ b/style.css
@@ -67,3 +67,8 @@
 }
 .es-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; }
 
+/* ===== No-JS fallbacks ===== */
+.es-fallback{ display:none; }
+.no-js .es-stage{ display:none; }
+.no-js .es-fallback{ display:block; }
+


### PR DESCRIPTION
## Summary
- Add `no-js` class via `body_class` filter for JS detection
- Strip `no-js` on script load
- Add `.no-js` CSS selectors to hide JS carousel and reveal fallback

## Testing
- `php -l functions.php`
- `node --check assets/child.js`

------
https://chatgpt.com/codex/tasks/task_e_68a7be9682bc83288e509146c5223fdc