### PR TITLE
Add child theme textdomain support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,5 +1,9 @@
 <?php
 require_once __DIR__ . '/utils.php';
+
+add_action( 'after_setup_theme', function () {
+  load_child_theme_textdomain( 'kadence-child', get_stylesheet_directory() . '/languages' );
+} );
 /**
  * Kadence Child – enqueue styles & JS
  */

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
  Template: kadence
  Version: 0.0.1
  Description: Minimal child theme for custom blocks, patterns, and styles.
+ Text Domain: kadence-child
 */
 
 /* --- Smoke test: change footer bg so we can confirm deploys --- */


### PR DESCRIPTION
## Summary
- add text domain header to the child theme's stylesheet
- load the child's textdomain during `after_setup_theme`

## Testing
- `npm test` (fails: ENOENT no package.json)
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3d810788328b16c7e2a72195c5c