### PR TITLE
Remove stray debug references

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -154,7 +154,7 @@ document.body.classList.remove('no-js');
     stage?.addEventListener('touchmove',  onTouchMove,  {passive:true});
     stage?.addEventListener('touchend', onTouchEnd);
 
-    codex/track-and-clean-up-initialized-rings
+    // codex/track-and-clean-up-initialized-rings
     console.log('[es-carousel] ready', {tiles:N, radius});
 
     const cleanup = () => {
@@ -176,8 +176,6 @@ document.body.classList.remove('no-js');
     };
 
     CLEANUPS.set(ring, cleanup);
-
-main
   };
 
   const initAll = () => {


### PR DESCRIPTION
## Summary
- comment leftover `codex/track-and-clean-up-initialized-rings` directive to prevent runtime errors
- remove orphaned `main` statement after carousel initialization cleanup

## Testing
- `node --check assets/child.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ec2cb1bc83288aa49f5617bb88a3