### PR TITLE
Revamp hero-ultimate pattern with badges and chips

### DIFF
--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -6,9 +6,9 @@
  * Description: Full-bleed hero with layered parallax, animated headline, and dual CTAs.
  */
 ?>
-<!-- wp:cover {"dimRatio":30,"isUserOverlayColor":true,"overlayColor":"black","minHeight":80,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
+<!-- wp:cover {"dimRatio":0,"isUserOverlayColor":true,"customGradient":"linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)","minHeight":80,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
 <div class="wp-block-cover alignfull kc-hero-ultimate" style="padding-top:80px;padding-bottom:80px;min-height:80vh">
-  <span aria-hidden="true" class="wp-block-cover__background has-black-background-color has-background-dim-30 has-background-dim"></span>
+  <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background:linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)"></span>
   <!-- Set your background image in block settings after inserting the pattern -->
   <img class="wp-block-cover__image-background" alt="" data-object-fit="cover"/>
   <div class="wp-block-cover__inner-container">
@@ -18,29 +18,71 @@
       <div class="kc-float a"></div>
       <div class="kc-float b"></div>
 
-      <!-- wp:paragraph {"className":"kc-eyebrow"} -->
-      <p class="kc-eyebrow">Countertops • Fabrication • Installation</p>
-      <!-- /wp:paragraph -->
+      <!-- wp:group {"className":"kc-hero-flex","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
+      <div class="wp-block-group kc-hero-flex">
+        <!-- Left column -->
+        <!-- wp:group {"className":"kc-hero-left","layout":{"type":"flex","orientation":"vertical"}} -->
+        <div class="wp-block-group kc-hero-left">
+          <!-- wp:paragraph {"className":"kc-eyebrow"} -->
+          <p class="kc-eyebrow">Countertops • Fabrication • Installation</p>
+          <!-- /wp:paragraph -->
 
-      <!-- wp:heading {"level":1,"className":"kc-hero-title"} -->
-      <h1 class="kc-hero-title"><span class="kc-reveal">Premium Countertops,</span> <span class="kc-reveal">Done Right.</span></h1>
-      <!-- /wp:heading -->
+          <!-- wp:heading {"level":1,"className":"kc-hero-title"} -->
+          <h1 class="kc-hero-title"><span class="kc-reveal">Premium Countertops</span> <span class="kc-reveal">Across Wisconsin.</span></h1>
+          <!-- /wp:heading -->
 
-      <!-- wp:paragraph {"className":"kc-hero-sub"} -->
-      <p class="kc-hero-sub">Quartz, Solid Surface, and Laminate—crafted, delivered, and installed with care across Greater Green Bay.</p>
-      <!-- /wp:paragraph -->
+          <!-- wp:paragraph {"className":"kc-hero-sub"} -->
+          <p class="kc-hero-sub">Quartz, natural stone, solid surface, and laminate—crafted, delivered, and installed statewide with 5-star care.</p>
+          <!-- /wp:paragraph -->
 
-      <!-- wp:buttons {"className":"kc-hero-ctas"} -->
-      <div class="wp-block-buttons kc-hero-ctas">
-        <!-- wp:button {"className":"is-style-fill kc-cta-primary"} -->
-        <div class="wp-block-button is-style-fill kc-cta-primary"><a class="wp-block-button__link wp-element-button" href="/contact">Get a Quote</a></div>
-        <!-- /wp:button -->
+          <!-- wp:buttons {"className":"kc-hero-ctas"} -->
+          <div class="wp-block-buttons kc-hero-ctas">
+            <!-- wp:button {"className":"is-style-fill kc-cta-primary"} -->
+            <div class="wp-block-button is-style-fill kc-cta-primary"><a class="wp-block-button__link wp-element-button" href="/contact">Get a Quote</a></div>
+            <!-- /wp:button -->
 
-        <!-- wp:button {"className":"is-style-outline kc-cta-secondary"} -->
-        <div class="wp-block-button is-style-outline kc-cta-secondary"><a class="wp-block-button__link wp-element-button" href="/gallery">View Colors</a></div>
-        <!-- /wp:button -->
+            <!-- wp:button {"className":"is-style-outline kc-cta-secondary"} -->
+            <div class="wp-block-button is-style-outline kc-cta-secondary"><a class="wp-block-button__link wp-element-button" href="/gallery">View Colors</a></div>
+            <!-- /wp:button -->
+          </div>
+          <!-- /wp:buttons -->
+
+          <!-- wp:group {"className":"kc-hero-badges","layout":{"type":"flex","flexWrap":"wrap"}} -->
+          <div class="wp-block-group kc-hero-badges">
+            <!-- wp:paragraph {"className":"kc-info-badge"} -->
+            <p class="kc-info-badge">Statewide – Wisconsin</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:paragraph {"className":"kc-info-badge"} -->
+            <p class="kc-info-badge">5 Star Rated</p>
+            <!-- /wp:paragraph -->
+          </div>
+          <!-- /wp:group -->
+        </div>
+        <!-- /wp:group -->
+
+        <!-- Right column -->
+        <!-- wp:group {"className":"kc-hero-chips","layout":{"type":"flex","orientation":"vertical"}} -->
+        <div class="wp-block-group kc-hero-chips">
+          <!-- wp:paragraph {"className":"kc-chip"} -->
+          <p class="kc-chip">Quartz</p>
+          <!-- /wp:paragraph -->
+
+          <!-- wp:paragraph {"className":"kc-chip"} -->
+          <p class="kc-chip">Natural Stone</p>
+          <!-- /wp:paragraph -->
+
+          <!-- wp:paragraph {"className":"kc-chip"} -->
+          <p class="kc-chip">Solid Surface</p>
+          <!-- /wp:paragraph -->
+
+          <!-- wp:paragraph {"className":"kc-chip"} -->
+          <p class="kc-chip">Laminate</p>
+          <!-- /wp:paragraph -->
+        </div>
+        <!-- /wp:group -->
       </div>
-      <!-- /wp:buttons -->
+      <!-- /wp:group -->
 
       <div class="kc-scroll-cue" aria-hidden="true">Scroll</div>
     </div>


### PR DESCRIPTION
## Summary
- Rework hero layout into left/right groups with CTAs, badges and product chips
- Update headline and subtext copy for statewide messaging
- Apply left-to-right gradient overlay for improved legibility

## Testing
- `php -l patterns/hero-ultimate.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee34421c8328802fbb0807ce4eec