### PR TITLE
Remove stray lines from hero-ultimate pattern

### DIFF
--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -18,7 +18,6 @@
       <div class="kc-float a"></div>
       <div class="kc-float b"></div>
 
-codex/update-hero-ultimate.php-copy
         <!-- wp:paragraph {"className":"kc-eyebrow"} -->
         <p class="kc-eyebrow">Countertops for every space • Wisconsin.</p>
         <!-- /wp:paragraph -->
@@ -108,7 +107,6 @@ codex/update-hero-ultimate.php-copy
         <!-- /wp:group -->
       </div>
       <!-- /wp:group -->
- main
 
       <div class="kc-scroll-cue" aria-hidden="true">Scroll</div>
     </div>


### PR DESCRIPTION
## Summary
- remove stray codex file reference from hero-ultimate pattern
- drop stray `main` line before scroll cue div

## Testing
- `php -l patterns/hero-ultimate.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7f1158ad48328ab086cd0cf0d2484