### PR TITLE
feat: add debug flag for carousel log

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,5 +1,8 @@
 document.body.classList.remove('no-js');
 
+// toggle verbose logging
+const DEBUG = false;
+
 // HERO reveal (unchanged)
 (function () {
   const title = document.querySelector('.kc-hero-title');
@@ -155,7 +158,7 @@ document.body.classList.remove('no-js');
     stage?.addEventListener('touchend', onTouchEnd);
 
     // codex/track-and-clean-up-initialized-rings
-    console.log('[es-carousel] ready', {tiles:N, radius});
+    DEBUG && console.log('[es-carousel] ready', { tiles: N, radius });
 
     const cleanup = () => {
       active = false;


### PR DESCRIPTION
## Summary
- add configurable DEBUG flag
- guard es-carousel readiness log behind debug flag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f11c64008328a092188e34392f35