### PR TITLE
Refine hero layout and interactions

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -14,7 +14,7 @@ const DEBUG = false;
 })();
 // ===== ES CAROUSEL (clean reset) =====
 (function(){
-  const GAP=24, TIGHT=0.72, MIN_R=260, MAX_R=620, TILT=8, SPEED=28; // sec/rev
+  const GAP=24, TIGHT=0.72, MIN_R=260, MAX_R=620, TILT=0, SPEED=28; // sec/rev
   const $ = (s, r=document) => r.querySelector(s);
   const $$ = (s, r=document) => [...r.querySelectorAll(s)];
   const CLEANUPS = new WeakMap();

--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -6,8 +6,8 @@
  * Description: Full-bleed hero with layered parallax, animated headline, and dual CTAs.
  */
 ?>
-<!-- wp:cover {"dimRatio":0,"isUserOverlayColor":true,"customGradient":"linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)","minHeight":80,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
-<div class="wp-block-cover alignfull kc-hero-ultimate" style="padding-top:80px;padding-bottom:80px;min-height:80vh">
+<!-- wp:cover {"dimRatio":0,"isUserOverlayColor":true,"customGradient":"linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)","minHeight":60,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
+<div class="wp-block-cover alignfull kc-hero-ultimate" style="padding-top:80px;padding-bottom:80px;min-height:60vh">
   <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background:linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)"></span>
   <!-- Set your background image in block settings after inserting the pattern -->
   <img class="wp-block-cover__image-background" alt="" data-object-fit="cover"/>
@@ -26,6 +26,18 @@
           <!-- wp:paragraph {"className":"kc-eyebrow"} -->
           <p class="kc-eyebrow">Countertops • Fabrication • Installation</p>
           <!-- /wp:paragraph -->
+
+          <!-- wp:group {"className":"kc-hero-badges","layout":{"type":"flex","flexWrap":"wrap"}} -->
+          <div class="wp-block-group kc-hero-badges">
+            <!-- wp:paragraph {"className":"kc-info-badge"} -->
+            <p class="kc-info-badge">Statewide – Wisconsin</p>
+            <!-- /wp:paragraph -->
+
+            <!-- wp:paragraph {"className":"kc-info-badge"} -->
+            <p class="kc-info-badge">5 Star Rated</p>
+            <!-- /wp:paragraph -->
+          </div>
+          <!-- /wp:group -->
 
           <!-- wp:heading {"level":1,"className":"kc-hero-title"} -->
           <h1 class="kc-hero-title"><span class="kc-reveal">Premium Countertops</span> <span class="kc-reveal">Across Wisconsin.</span></h1>
@@ -46,43 +58,31 @@
             <!-- /wp:button -->
           </div>
           <!-- /wp:buttons -->
-
-          <!-- wp:group {"className":"kc-hero-badges","layout":{"type":"flex","flexWrap":"wrap"}} -->
-          <div class="wp-block-group kc-hero-badges">
-            <!-- wp:paragraph {"className":"kc-info-badge"} -->
-            <p class="kc-info-badge">Statewide – Wisconsin</p>
-            <!-- /wp:paragraph -->
-
-            <!-- wp:paragraph {"className":"kc-info-badge"} -->
-            <p class="kc-info-badge">5 Star Rated</p>
-            <!-- /wp:paragraph -->
-          </div>
-          <!-- /wp:group -->
         </div>
         <!-- /wp:group -->
 
         <!-- Right column -->
         <!-- wp:group {"className":"kc-hero-chips","layout":{"type":"flex","orientation":"vertical"}} -->
         <div class="wp-block-group kc-hero-chips">
-          <!-- wp:paragraph {"className":"kc-chip"} -->
-          <p class="kc-chip">Quartz</p>
-          <!-- /wp:paragraph -->
+          <!-- wp:html -->
+          <a class="kc-chip" href="/quartz">Quartz</a>
+          <!-- /wp:html -->
 
-          <!-- wp:paragraph {"className":"kc-chip"} -->
-          <p class="kc-chip">Natural Stone</p>
-          <!-- /wp:paragraph -->
+          <!-- wp:html -->
+          <a class="kc-chip" href="/natural-stone">Natural Stone</a>
+          <!-- /wp:html -->
 
-          <!-- wp:paragraph {"className":"kc-chip"} -->
-          <p class="kc-chip">Solid Surface</p>
-          <!-- /wp:paragraph -->
+          <!-- wp:html -->
+          <a class="kc-chip" href="/solid-surface">Solid Surface</a>
+          <!-- /wp:html -->
 
-          <!-- wp:paragraph {"className":"kc-chip"} -->
-          <p class="kc-chip">Laminate</p>
-          <!-- /wp:paragraph -->
+          <!-- wp:html -->
+          <a class="kc-chip" href="/laminate">Laminate</a>
+          <!-- /wp:html -->
 
-          <!-- wp:paragraph {"className":"kc-chip"} -->
-          <p class="kc-chip">Ultra Compact</p>
-          <!-- /wp:paragraph -->
+          <!-- wp:html -->
+          <a class="kc-chip" href="/ultra-compact">Ultra Compact</a>
+          <!-- /wp:html -->
         </div>
         <!-- /wp:group -->
         </div>
@@ -92,7 +92,7 @@
         <div class="wp-block-group kc-ring-wrap">
           <!-- wp:html -->
           <div class="es-stage">
-            <div class="es-ring" data-radius="560" data-speed="30" data-tilt="8">
+            <div class="es-ring" data-radius="560" data-speed="30" data-tilt="0">
               <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Wilsonart-01.png" alt="Wilsonart"></div>
               <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vicostone-01.png" alt="Vicostone"></div>
               <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Viatera-01.png" alt="Viatera"></div>

--- a/style.css
+++ b/style.css
@@ -11,7 +11,7 @@
 
 /* Your custom CSS below */
 /* ==== HERO ULTIMATE ==== */
-.kc-hero-ultimate { position:relative; }
+.kc-hero-ultimate { position:relative; min-height:60vh; }
 .kc-hero-ultimate .wp-block-cover__background{ background:linear-gradient(90deg, rgba(0,0,0,0.65), transparent); opacity:1!important; }
 .kc-hero-wrap { position:relative; color:#fff; text-align:left; }
 .kc-hero-chips{ position:absolute; top:24px; right:24px; display:flex; flex-direction:column; gap:clamp(6px,1vw,10px); }
@@ -21,9 +21,12 @@
 
 .kc-info-badge{ display:inline-block; background:rgba(255,255,255,.15); padding:.25em .6em; border-radius:4px; font-size:.75rem; line-height:1; }
 
+.kc-hero-badges{ display:flex; gap:1rem; margin-bottom:1rem; }
+
 .kc-chip-stack{ position:absolute; right:0; top:50%; transform:translateY(-50%); display:flex; flex-direction:column; gap:clamp(6px,1vw,10px); z-index:1; }
-.kc-chip{ display:flex; align-items:center; background:rgba(0,0,0,.35); color:#fff; padding:.45rem .8rem; border-radius:clamp(8px,1.5vw,12px); transition:background .2s ease; }
-.kc-chip:hover{ background:rgba(0,0,0,.5); }
+.kc-chip{ display:block; text-align:center; background:rgba(0,0,0,.35); color:#fff; padding:.45rem .8rem; border-radius:clamp(8px,1.5vw,12px); text-decoration:none; font-weight:600; box-shadow:0 2px 4px rgba(0,0,0,.1); transition:background .2s ease, transform .25s ease, box-shadow .25s ease; }
+.kc-chip:hover,
+.kc-chip:focus{ background:rgba(0,0,0,.5); transform:translateX(6px) scale(1.03); box-shadow:0 4px 8px rgba(0,0,0,.15); }
 
 @media (max-width: 782px){ .kc-chip-stack{ position:static; transform:none; flex-direction:row; flex-wrap:wrap; margin-top:clamp(16px,3vw,24px); } }
 
@@ -51,18 +54,18 @@
 /* Scroll cue */
 .kc-scroll-cue{ position:absolute; left:50%; bottom:clamp(6px,1vw,10px); transform:translateX(-50%); font-size:.8rem; letter-spacing:.2em; opacity:.7 }
 @media (max-width: 782px){ .kc-hero-sub{ max-width:100%; } }
-.kc-ring-wrap{ display:flex; justify-content:center; margin-top:64px; }
+.kc-ring-wrap{ display:flex; justify-content:center; margin-top:32px; }
 /* ===== ES CAROUSEL (namespaced, clean) ===== */
 .es-stage{
   position:relative; width:100%;
-  height:clamp(320px,80vw,560px); perspective:clamp(1000px,180vw,1600px); perspective-origin:50% 42%;
+  height:clamp(260px,60vw,480px); perspective:clamp(900px,160vw,1400px); perspective-origin:50% 42%;
   overflow:visible;
 }
 .es-ring{
   position:absolute; top:50%; left:50%;
   transform-style:preserve-3d;
   /* JS sets rotateY each frame; keep a stable base tilt only */
-  transform:translate(-50%,-50%) rotateX(8deg) rotateY(0deg);
+  transform:translate(-50%,-50%) rotateX(0deg) rotateY(0deg);
   will-change:transform;
 }
 .es-tile{


### PR DESCRIPTION
## Summary
- shrink hero min-height so entire hero and carousel fit on load
- level the brand carousel and reposition info badges
- turn material chips into animated links with destination pages

## Testing
- `php -l patterns/hero-ultimate.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b39900f083289fd18a9e918c2380