### PR TITLE
Fix hero carousel pattern slug

### DIFF
--- a/patterns/hero-showcase-carousel.php
+++ b/patterns/hero-showcase-carousel.php
@@ -62,7 +62,7 @@ add_action( 'init', function () {
 
     <!-- Reuse the existing, working carousel pattern -->
     <!-- IMPORTANT: This slug must match the existing pattern. -->
-    <!-- wp:pattern {"slug":"kadence-child/3d-carousel-ring"} /-->
+    <!-- wp:pattern {"slug":"kadence-child/carousel-3d-ring"} /-->
 
   </div>
 </section>


### PR DESCRIPTION
## Summary
- correct carousel pattern slug in hero showcase pattern

## Testing
- `php -l patterns/hero-showcase-carousel.php`
- `php -l patterns/carousel-3d-ring.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8d54a94c48328ae20ee8271abe58c