### PR TITLE
Add hero showcase pattern with carousel and styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The theme registers a `Kadence Child` pattern category and provides:
     - `data-tilt` – tilt angle in degrees (default `8`).
 - **Hero Intro** (`patterns/hero-intro.php`): simple headline and paragraph section.
 - **Hero – Ultimate (Motion)** (`patterns/hero-ultimate.php`): full‑bleed hero with parallax elements and dual CTAs.
+- **Hero — Showcase (with Carousel)** (`patterns/hero-showcase-carousel.php`): feature hero with category cards and an embedded 3D carousel.
 
 ## Development Workflow
 

--- a/assets/css/editor.css
+++ b/assets/css/editor.css
@@ -28,3 +28,15 @@
   max-width: 85%;
   max-height: 75%;
 }
+
+/* Editor preview for Hero Showcase with Carousel */
+.block-editor .kc-hero-showcase{position:relative;color:#fff;padding:40px 20px;min-height:400px;}
+.block-editor .kc-hero-showcase .kc-hero-bg{position:absolute;inset:0;background:var(--hero-bg) center/cover no-repeat;z-index:-2;}
+.block-editor .kc-hero-showcase .kc-hero-scrim{position:absolute;inset:0;background:linear-gradient(120deg,rgba(0,0,0,.65),rgba(0,0,0,.35));z-index:-1;}
+.block-editor .kc-hero-showcase .kc-hero-wrap{position:relative;display:flex;flex-direction:column;gap:40px;}
+.block-editor .kc-hero-showcase .kc-hero-grid{display:grid;grid-template-columns:1fr 1fr;gap:40px;align-items:center;}
+.block-editor .kc-hero-showcase .kc-hero-right{display:grid;grid-template-columns:repeat(2,1fr);gap:16px;width:100%;}
+.block-editor .kc-hero-showcase .kc-card{background:rgba(255,255,255,.1);border-radius:8px;padding:16px;text-align:center;color:#fff;}
+.block-editor .kc-hero-showcase .kc-card--wide{grid-column:span 2;}
+.block-editor .kc-hero-showcase .kc-cta-bar{display:none;}
+@media (max-width:782px){.block-editor .kc-hero-showcase .kc-hero-grid{grid-template-columns:1fr;}.block-editor .kc-hero-showcase .kc-hero-right{grid-template-columns:repeat(3,1fr);}.block-editor .kc-hero-showcase .kc-card--wide{grid-column:span 3;}}

--- a/patterns/hero-showcase-carousel.php
+++ b/patterns/hero-showcase-carousel.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Pattern: Hero — Showcase (with Carousel)
+ * Location: Patterns → Kadence Child
+ */
+
+if ( ! function_exists( 'register_block_pattern' ) ) { return; }
+
+add_action( 'init', function () {
+
+  // Ensure our pattern category exists (safe to re-run).
+  if ( function_exists( 'register_block_pattern_category' ) ) {
+    register_block_pattern_category(
+      'kadence-child',
+      array( 'label' => __( 'Kadence Child', 'kadence-child' ) )
+    );
+  }
+
+  $content = <<<'HTML'
+<!-- wp:group {"tagName":"section","className":"kc-hero-showcase","layout":{"type":"constrained"}} -->
+<section class="kc-hero-showcase" aria-label="Premium Countertops Hero">
+  <div class="kc-hero-bg" style="--hero-bg:url('BACKGROUND_IMAGE_URL');"></div>
+  <div class="kc-hero-scrim"></div>
+
+  <div class="kc-hero-wrap">
+    <div class="kc-hero-grid">
+      <!-- LEFT -->
+      <header class="kc-hero-left">
+        <p class="kc-eyebrow">Countertops for every space · <span class="nowrap">Wisconsin</span></p>
+        <h1 class="kc-heading">
+          Premium Countertops
+          <span class="kc-break">without the Premium</span>
+          <span class="kc-highlight">Headache.</span>
+        </h1>
+        <p class="kc-sub">
+          Shop quartz, natural stone, solid surface, laminate, and ultra-compact materials—installed by local pros.
+          Precise fabrication, seamless installs, and free in-home measures.
+        </p>
+
+        <nav class="kc-cta-row" aria-label="Primary actions">
+          <a class="kc-btn kc-btn--primary" href="/free-quote">Schedule Your Free Quote</a>
+          <a class="kc-btn kc-btn--ghost" href="/color-samples">Explore Countertop Colors</a>
+        </nav>
+      </header>
+
+      <!-- RIGHT -->
+      <aside class="kc-hero-right" aria-label="Browse categories">
+        <a class="kc-card" href="/quartz"><span class="kc-card-title">Quartz</span></a>
+        <a class="kc-card" href="/natural-stone"><span class="kc-card-title">Natural Stone</span></a>
+        <a class="kc-card" href="/solid-surface"><span class="kc-card-title">Solid Surface</span></a>
+        <a class="kc-card" href="/ultra-compact"><span class="kc-card-title">Ultra Compact</span></a>
+        <a class="kc-card kc-card--wide" href="/laminate"><span class="kc-card-title">Laminate</span></a>
+        <a class="kc-card kc-card--wide" href="/sinks"><span class="kc-card-title">Sinks</span></a>
+      </aside>
+    </div>
+
+    <!-- CTA BAR -->
+    <div class="kc-cta-bar" role="region" aria-label="Quick actions">
+      <a class="kc-pill" href="/free-quote">Schedule Your Free Quote</a>
+      <a class="kc-pill kc-pill--ghost" href="/color-samples">Explore Countertop Colors</a>
+    </div>
+
+    <!-- Reuse the existing, working carousel pattern -->
+    <!-- IMPORTANT: This slug must match the existing pattern. -->
+    <!-- wp:pattern {"slug":"kadence-child/3d-carousel-ring"} /-->
+
+  </div>
+</section>
+<!-- /wp:group -->
+HTML;
+
+  register_block_pattern(
+    'kadence-child/hero-showcase-carousel',
+    array(
+      'title'       => __( 'Hero — Showcase (with Carousel)', 'kadence-child' ),
+      'categories'  => array( 'kadence-child' ),
+      'content'     => $content,
+    )
+  );
+});

--- a/style.css
+++ b/style.css
@@ -89,3 +89,29 @@
 .es-fallback{ display:none; }
 .no-js .es-stage{ display:none; }
 .no-js .es-fallback{ display:block; }
+
+/* ==== HERO SHOWCASE (with Carousel) ==== */
+.kc-hero-showcase{position:relative;color:#fff;}
+.kc-hero-showcase .kc-hero-bg{position:absolute;inset:0;background:var(--hero-bg) center/cover no-repeat;z-index:-2;}
+.kc-hero-showcase .kc-hero-scrim{position:absolute;inset:0;background:linear-gradient(120deg,rgba(0,0,0,.65),rgba(0,0,0,.35));z-index:-1;}
+.kc-hero-showcase .kc-hero-wrap{position:relative;display:flex;flex-direction:column;gap:clamp(32px,6vw,72px);padding:clamp(40px,8vw,120px) clamp(16px,5vw,80px);}
+.kc-hero-showcase .kc-hero-grid{display:grid;grid-template-columns:1fr auto;gap:clamp(32px,5vw,80px);align-items:center;}
+.kc-hero-showcase .kc-hero-left{max-width:60ch;}
+.kc-hero-showcase .kc-eyebrow{letter-spacing:.15em;text-transform:uppercase;font-size:.8rem;margin:0 0 .75rem;opacity:.85;}
+.kc-hero-showcase .kc-heading{margin:0 0 1rem;font-weight:800;line-height:1.05;font-size:clamp(32px,5vw,64px);}
+.kc-hero-showcase .kc-break{display:block;}
+.kc-hero-showcase .kc-highlight{color:var(--global-palette1,#fff);}
+.kc-hero-showcase .kc-sub{margin:0 0 1.5rem;font-size:clamp(16px,1.6vw,22px);opacity:.9;}
+.kc-hero-showcase .kc-cta-row{display:flex;flex-wrap:wrap;gap:16px;}
+.kc-hero-showcase .kc-btn{display:inline-block;padding:.9rem 1.25rem;border-radius:8px;font-weight:600;text-decoration:none;}
+.kc-hero-showcase .kc-btn--primary{background:#111;color:#fff;}
+.kc-hero-showcase .kc-btn--ghost{border:2px solid rgba(255,255,255,.85);color:#fff;}
+.kc-hero-showcase .kc-hero-right{display:grid;grid-template-columns:repeat(2,1fr);gap:clamp(12px,1.8vw,20px);width:clamp(220px,25vw,360px);}
+.kc-hero-showcase .kc-card{position:relative;display:flex;align-items:center;justify-content:center;background:rgba(255,255,255,.1);color:#fff;text-decoration:none;border-radius:10px;padding:clamp(20px,2vw,24px);text-align:center;font-weight:700;transition:.25s;}
+.kc-hero-showcase .kc-card:hover{background:rgba(255,255,255,.18);}
+.kc-hero-showcase .kc-card--wide{grid-column:span 2;}
+.kc-hero-showcase .kc-cta-bar{display:none;gap:12px;}
+.kc-hero-showcase .kc-pill{display:inline-block;padding:.75rem 1rem;border-radius:999px;font-weight:600;text-decoration:none;background:#111;color:#fff;}
+.kc-hero-showcase .kc-pill--ghost{background:transparent;border:2px solid rgba(255,255,255,.85);}
+@media (max-width:1024px){.kc-hero-showcase .kc-hero-grid{grid-template-columns:1fr;}.kc-hero-showcase .kc-hero-right{width:100%;grid-template-columns:repeat(3,1fr);}.kc-hero-showcase .kc-card--wide{grid-column:span 3;}}
+@media (max-width:782px){.kc-hero-showcase .kc-cta-row{display:none;}.kc-hero-showcase .kc-cta-bar{display:flex;flex-wrap:wrap;}.kc-hero-showcase .kc-hero-wrap{gap:clamp(24px,6vw,48px);} }


### PR DESCRIPTION
## Summary
- add Hero — Showcase (with Carousel) block pattern that reuses the 3D carousel pattern
- style hero showcase pattern on frontend and in editor
- document new hero showcase carousel pattern in readme

## Testing
- `php -l patterns/hero-showcase-carousel.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8d1d493108328abfa8176be73ee51