### PR TITLE
Refactor hero showcase carousel pattern for auto registration

### DIFF
--- a/patterns/hero-showcase-carousel.php
+++ b/patterns/hero-showcase-carousel.php
@@ -1,24 +1,11 @@
 <?php
 /**
- * Pattern: Hero — Showcase (with Carousel)
- * Location: Patterns → Kadence Child
+ * Title: Hero — Showcase (with Carousel)
+ * Slug: kadence-child/hero-showcase-carousel
+ * Categories: kadence-child
  */
+?>
 
-if ( ! function_exists( 'register_block_pattern' ) ) {
-  return;
-}
-
-add_action( 'init', function () {
-
-  // Ensure our pattern category exists (safe to re-run).
-  if ( function_exists( 'register_block_pattern_category' ) ) {
-    register_block_pattern_category(
-      'kadence-child',
-      array( 'label' => __( 'Kadence Child', 'kadence-child' ) )
-    );
-  }
-
-  $content = <<<'HTML'
 <!-- wp:group {"tagName":"section","className":"kc-hero-showcase","layout":{"type":"constrained"}} -->
 <section class="kc-hero-showcase" aria-label="Premium Countertops Hero">
   <div class="kc-hero-bg" style="--hero-bg:url('BACKGROUND_IMAGE_URL');"></div>
@@ -69,14 +56,4 @@ add_action( 'init', function () {
   </div>
 </section>
 <!-- /wp:group -->
-HTML;
 
-  register_block_pattern(
-    'kadence-child/hero-showcase-carousel',
-    array(
-      'title'       => __( 'Hero — Showcase (with Carousel)', 'kadence-child' ),
-      'categories'  => array( 'kadence-child' ),
-      'content'     => $content,
-    )
-  );
-});


### PR DESCRIPTION
## Summary
- simplify `hero-showcase-carousel` pattern by converting to header+markup format
- drop `init` hook and `register_block_pattern` logic for auto-registration

## Testing
- `php -l patterns/hero-showcase-carousel.php`


------
https://chatgpt.com/codex/tasks/task_e_68a912efcbd883288cef7913ca5f8831