### PR TITLE
feat: add material-specific color modifiers

### DIFF
--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -68,31 +68,31 @@
             <!-- wp:html -->
             <div class="kc-material-grid">
               <a href="/quartz">
-                <figure class="kc-material-card">
+                <figure class="kc-material-card kc-material-quartz">
                   <img src="https://via.placeholder.com/80?text=Quartz" alt="Quartz" />
                   <figcaption>Quartz</figcaption>
                 </figure>
               </a>
               <a href="/natural-stone">
-                <figure class="kc-material-card">
+                <figure class="kc-material-card kc-material-stone">
                   <img src="https://via.placeholder.com/80?text=Stone" alt="Natural Stone" />
                   <figcaption>Natural Stone</figcaption>
                 </figure>
               </a>
               <a href="/solid-surface">
-                <figure class="kc-material-card">
+                <figure class="kc-material-card kc-material-solid">
                   <img src="https://via.placeholder.com/80?text=Solid" alt="Solid Surface" />
                   <figcaption>Solid Surface</figcaption>
                 </figure>
               </a>
               <a href="/ultra-compact">
-                <figure class="kc-material-card">
+                <figure class="kc-material-card kc-material-ultra">
                   <img src="https://via.placeholder.com/80?text=Ultra" alt="Ultra Compact" />
                   <figcaption>Ultra Compact</figcaption>
                 </figure>
               </a>
               <a href="/laminate">
-                <figure class="kc-material-card">
+                <figure class="kc-material-card kc-material-laminate">
                   <img src="https://via.placeholder.com/80?text=Lam" alt="Laminate" />
                   <figcaption>Laminate</figcaption>
                 </figure>

--- a/style.css
+++ b/style.css
@@ -25,11 +25,18 @@
 
 .kc-hero-ultimate .kc-material-grid{ display:grid; gap:clamp(12px,1.5vw,20px); grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
 .kc-hero-ultimate .kc-material-grid a{ text-decoration:none; color:inherit; }
-.kc-hero-ultimate .kc-material-card{ display:flex; flex-direction:column; align-items:center; text-align:center; padding:1rem; background:linear-gradient(145deg,#0d1117,#1b2433); color:#fff; border-radius:12px; border:1px solid rgba(255,255,255,.1); box-shadow:0 6px 12px rgba(0,0,0,.25); transition:transform .25s ease, box-shadow .25s ease, background .25s ease; }
-.kc-hero-ultimate .kc-material-card:hover{ background:linear-gradient(145deg,#1b2433,#0d1117); transform:translateY(-4px); box-shadow:0 10px 20px rgba(0,0,0,.35); }
+.kc-hero-ultimate .kc-material-card{ display:flex; flex-direction:column; align-items:center; text-align:center; padding:1rem; background:linear-gradient(145deg,var(--kc-mat-bg1,#0d1117),var(--kc-mat-bg2,#1b2433)); color:#fff; border-radius:12px; border:1px solid var(--kc-mat-stroke,rgba(255,255,255,.1)); box-shadow:0 6px 12px rgba(0,0,0,.25); transition:transform .25s ease, box-shadow .25s ease, background .25s ease; }
+.kc-hero-ultimate .kc-material-card:hover{ background:linear-gradient(145deg,var(--kc-mat-bg2,#1b2433),var(--kc-mat-bg1,#0d1117)); transform:translateY(-4px); box-shadow:0 10px 20px rgba(0,0,0,.35); }
 .kc-hero-ultimate .kc-material-card img{ width:64px; height:64px; object-fit:contain; margin-bottom:.5rem; }
 .kc-hero-ultimate .kc-material-card figcaption{ font-weight:700; }
 @media (max-width: 782px){ .kc-hero-ultimate .kc-material-grid{ grid-template-columns:1fr; } }
+
+/* Material modifiers */
+.kc-material-quartz{ --kc-mat-bg1:#3e3052; --kc-mat-bg2:#1d1a2d; --kc-mat-stroke:rgba(255,255,255,.2); }
+.kc-material-stone{ --kc-mat-bg1:#28321e; --kc-mat-bg2:#141b10; --kc-mat-stroke:rgba(255,255,255,.2); }
+.kc-material-solid{ --kc-mat-bg1:#1d4040; --kc-mat-bg2:#0e2324; --kc-mat-stroke:rgba(255,255,255,.2); }
+.kc-material-ultra{ --kc-mat-bg1:#1a2238; --kc-mat-bg2:#0d1220; --kc-mat-stroke:rgba(255,255,255,.2); }
+.kc-material-laminate{ --kc-mat-bg1:#3b211a; --kc-mat-bg2:#1d0f0a; --kc-mat-stroke:rgba(255,255,255,.2); }
 
 
 /* Headline reveal */


### PR DESCRIPTION
## Summary
- add material modifier CSS classes with unique color variables
- apply new material classes to hero pattern cards

## Testing
- `php -l patterns/hero-ultimate.php`
- `python contrast_check.py`

------
https://chatgpt.com/codex/tasks/task_e_68a92b17121483289823339201e29927