### PR TITLE
Refactor material chips into accessible list

### DIFF
--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -66,38 +66,38 @@
           <!-- wp:group {"className":"kc-hero-chips","layout":{"type":"constrained"}} -->
           <div class="wp-block-group kc-hero-chips">
             <!-- wp:html -->
-            <div class="kc-material-grid">
-              <a href="/quartz">
-                <figure class="kc-material-card kc-material-quartz">
-                  <img src="https://via.placeholder.com/80?text=Quartz" alt="Quartz" />
-                  <figcaption>Quartz</figcaption>
-                </figure>
-              </a>
-              <a href="/natural-stone">
-                <figure class="kc-material-card kc-material-stone">
-                  <img src="https://via.placeholder.com/80?text=Stone" alt="Natural Stone" />
-                  <figcaption>Natural Stone</figcaption>
-                </figure>
-              </a>
-              <a href="/solid-surface">
-                <figure class="kc-material-card kc-material-solid">
-                  <img src="https://via.placeholder.com/80?text=Solid" alt="Solid Surface" />
-                  <figcaption>Solid Surface</figcaption>
-                </figure>
-              </a>
-              <a href="/ultra-compact">
-                <figure class="kc-material-card kc-material-ultra">
-                  <img src="https://via.placeholder.com/80?text=Ultra" alt="Ultra Compact" />
-                  <figcaption>Ultra Compact</figcaption>
-                </figure>
-              </a>
-              <a href="/laminate">
-                <figure class="kc-material-card kc-material-laminate">
-                  <img src="https://via.placeholder.com/80?text=Lam" alt="Laminate" />
-                  <figcaption>Laminate</figcaption>
-                </figure>
-              </a>
-            </div>
+            <ul class="kc-material-list">
+              <li>
+                <a class="kc-chip kc-material-quartz" href="/quartz" aria-label="Shop quartz countertops">
+                  <img src="https://via.placeholder.com/80?text=Quartz" alt="" />
+                  <span>Quartz</span>
+                </a>
+              </li>
+              <li>
+                <a class="kc-chip kc-material-stone" href="/natural-stone" aria-label="Shop natural stone countertops">
+                  <img src="https://via.placeholder.com/80?text=Stone" alt="" />
+                  <span>Natural Stone</span>
+                </a>
+              </li>
+              <li>
+                <a class="kc-chip kc-material-solid" href="/solid-surface" aria-label="Shop solid surface countertops">
+                  <img src="https://via.placeholder.com/80?text=Solid" alt="" />
+                  <span>Solid Surface</span>
+                </a>
+              </li>
+              <li>
+                <a class="kc-chip kc-material-ultra" href="/ultra-compact" aria-label="Shop ultra compact countertops">
+                  <img src="https://via.placeholder.com/80?text=Ultra" alt="" />
+                  <span>Ultra Compact</span>
+                </a>
+              </li>
+              <li>
+                <a class="kc-chip kc-material-laminate" href="/laminate" aria-label="Shop laminate countertops">
+                  <img src="https://via.placeholder.com/80?text=Lam" alt="" />
+                  <span>Laminate</span>
+                </a>
+              </li>
+            </ul>
             <!-- /wp:html -->
           </div>
           <!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -23,13 +23,13 @@
 
 .kc-hero-ultimate .kc-hero-badges{ display:flex; align-items:center; gap:1rem; margin-bottom:1rem; }
 
-.kc-hero-ultimate .kc-material-grid{ display:grid; gap:clamp(12px,1.5vw,20px); grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); }
-.kc-hero-ultimate .kc-material-grid a{ text-decoration:none; color:inherit; }
-.kc-hero-ultimate .kc-material-card{ display:flex; flex-direction:column; align-items:center; text-align:center; padding:1rem; background:linear-gradient(145deg,var(--kc-mat-bg1,#0d1117),var(--kc-mat-bg2,#1b2433)); color:#fff; border-radius:12px; border:1px solid var(--kc-mat-stroke,rgba(255,255,255,.1)); box-shadow:0 6px 12px rgba(0,0,0,.25); transition:transform .25s ease, box-shadow .25s ease, background .25s ease; }
-.kc-hero-ultimate .kc-material-card:hover{ background:linear-gradient(145deg,var(--kc-mat-bg2,#1b2433),var(--kc-mat-bg1,#0d1117)); transform:translateY(-4px); box-shadow:0 10px 20px rgba(0,0,0,.35); }
-.kc-hero-ultimate .kc-material-card img{ width:64px; height:64px; object-fit:contain; margin-bottom:.5rem; }
-.kc-hero-ultimate .kc-material-card figcaption{ font-weight:700; }
-@media (max-width: 782px){ .kc-hero-ultimate .kc-material-grid{ grid-template-columns:1fr; } }
+.kc-hero-ultimate .kc-material-list{ display:grid; gap:clamp(12px,1.5vw,20px); grid-template-columns:repeat(auto-fit,minmax(140px,1fr)); list-style:none; margin:0; padding:0; }
+.kc-hero-ultimate .kc-material-list .kc-chip{ text-decoration:none; color:inherit; display:flex; flex-direction:column; align-items:center; text-align:center; padding:1rem; background:linear-gradient(145deg,var(--kc-mat-bg1,#0d1117),var(--kc-mat-bg2,#1b2433)); color:#fff; border-radius:12px; border:1px solid var(--kc-mat-stroke,rgba(255,255,255,.1)); box-shadow:0 6px 12px rgba(0,0,0,.25); transition:transform .25s ease, box-shadow .25s ease, background .25s ease; }
+.kc-hero-ultimate .kc-material-list .kc-chip:hover{ background:linear-gradient(145deg,var(--kc-mat-bg2,#1b2433),var(--kc-mat-bg1,#0d1117)); transform:translateY(-4px); box-shadow:0 10px 20px rgba(0,0,0,.35); }
+.kc-hero-ultimate .kc-material-list .kc-chip img{ width:64px; height:64px; object-fit:contain; margin-bottom:.5rem; }
+.kc-hero-ultimate .kc-material-list .kc-chip span{ font-weight:700; }
+.kc-hero-ultimate .kc-material-list .kc-chip:focus-visible{ outline:2px solid #fff; outline-offset:2px; }
+@media (max-width: 782px){ .kc-hero-ultimate .kc-material-list{ grid-template-columns:1fr; } }
 
 /* Material modifiers */
 .kc-material-quartz{ --kc-mat-bg1:#3e3052; --kc-mat-bg2:#1d1a2d; --kc-mat-stroke:rgba(255,255,255,.2); }


### PR DESCRIPTION
## Summary
- wrap countertop material links in `<ul class="kc-material-list">` with `<li>` items
- style chips via `.kc-material-list .kc-chip` and show `:focus-visible` outline
- add descriptive `aria-label` attributes for screen readers

## Testing
- `php -l patterns/hero-ultimate.php`


------
https://chatgpt.com/codex/tasks/task_e_68a92f45716083289ae86087d2277ad3