### PR TITLE
Add optional hero card alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -395,6 +395,11 @@
   border-radius:20px;
 }
 
+/* Optional: tuck the card to the right inside the hero */
+.kc-hero-fore .kc-materials-card{
+  margin-left:auto;
+}
+
 /* Chip readability and tidy wrapping */
 .kc-chip{
   min-height:52px;                 /* a bit taller for two-line labels */


### PR DESCRIPTION
## Summary
- tuck hero materials card to the right within the hero

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a93fc975c083289e54ae98d016fd42