### PR TITLE
feat: add premium glass materials card styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -431,3 +431,122 @@
 @media (prefers-reduced-motion: reduce){
   .kc-ripple{ display:none !important; }
 }
+/* ===== Materials Card — Premium Glass ===== */
+.kc-materials-card{
+  position:relative;
+  max-width: 560px;
+  margin-inline:auto;
+  padding: clamp(16px,2vw,20px);
+  color:#fff;
+
+  /* Glass */
+  background:
+    linear-gradient(180deg, rgba(12,17,26,.70), rgba(6,8,15,.54));
+  border: 1px solid rgba(255,255,255,.14);
+  border-radius: 18px;
+  box-shadow: 0 18px 48px rgba(0,0,0,.38);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  overflow: visible; /* allow outer glow */
+}
+.kc-materials-card::before{
+  /* animated border glow */
+  content:"";
+  position:absolute; inset:-1px; padding:1px; border-radius:20px; pointer-events:none;
+  background: linear-gradient(120deg,
+             rgba(185,156,255,.45),
+             rgba(125,226,209,.35),
+             rgba(255,212,121,.35));
+  background-size:300% 100%;
+  mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor; mask-composite: exclude;
+  animation: kcHue 12s linear infinite;
+}
+.kc-materials-heading{
+  margin:0 0 12px;
+  text-align:center;
+  font-size: clamp(1.1rem, 2.2vw, 1.4rem);
+  font-weight:800;
+  letter-spacing:.3px;
+}
+
+/* Grid */
+.kc-material-grid{
+  display:grid;
+  grid-template-columns: repeat(2, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+/* Chip — luminous, no mid-word breaks */
+.kc-chip{
+  position:relative;
+  display:flex; align-items:center; justify-content:center;
+  min-height: 52px;
+  padding: 12px 16px;
+  text-decoration:none;
+  color:#fff;
+  font-weight: 800;
+  border-radius: 12px;
+
+  background: linear-gradient(180deg, rgba(24,28,38,.88), rgba(14,18,26,.78));
+  border:1px solid rgba(255,255,255,.12);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.06), 0 12px 26px rgba(0,0,0,.30);
+
+  transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease, background .18s ease;
+  will-change: transform;
+}
+.kc-txt{
+  line-height:1.05;
+  text-align:center;
+  white-space: normal;
+  word-break: keep-all;
+  overflow-wrap: normal;
+  hyphens: manual; /* allows <wbr> to be the only break */
+}
+/* sheen + inner highlight */
+.kc-chip::before{
+  content:""; position:absolute; inset:0; border-radius:inherit; pointer-events:none;
+  background:
+    radial-gradient(120% 90% at 10% 0%, rgba(255,255,255,.10), transparent 60%),
+    linear-gradient(180deg, rgba(255,255,255,.06), transparent 40%);
+  mix-blend-mode: screen; opacity:.8;
+}
+
+/* Hover/Focus depth */
+.kc-chip:hover,
+.kc-chip:focus-visible{
+  transform: translateY(-2px) scale(1.01);
+  border-color: rgba(255,255,255,.24);
+  box-shadow: 0 16px 34px rgba(0,0,0,.36), inset 0 1px 0 rgba(255,255,255,.10);
+  outline: none;
+}
+
+/* Accessible keyboard ring */
+.kc-chip:focus-visible{
+  box-shadow:
+    0 0 0 3px rgba(255,255,255,.25),
+    0 16px 34px rgba(0,0,0,.36),
+    inset 0 1px 0 rgba(255,255,255,.10);
+}
+
+/* Subtle per-chip accent ring */
+.kc-quartz:hover{ box-shadow: 0 16px 34px rgba(111,125,255,.32), inset 0 1px 0 rgba(255,255,255,.10); }
+.kc-stone:hover { box-shadow: 0 16px 34px rgba(125,226,209,.28), inset 0 1px 0 rgba(255,255,255,.10); }
+.kc-solid:hover { box-shadow: 0 16px 34px rgba(255,212,121,.28), inset 0 1px 0 rgba(255,255,255,.10); }
+.kc-ultra:hover { box-shadow: 0 16px 34px rgba(217,153,255,.28), inset 0 1px 0 rgba(255,255,255,.10); }
+.kc-lam:hover   { box-shadow: 0 16px 34px rgba(255,138,128,.28), inset 0 1px 0 rgba(255,255,255,.10); }
+.kc-sinks:hover { box-shadow: 0 16px 34px rgba(128,223,255,.28), inset 0 1px 0 rgba(255,255,255,.10); }
+
+/* Optional: push card to the right on wide screens */
+@media (min-width: 992px){
+  .kc-hero-fore .kc-materials-card{ margin-left:auto; }
+}
+
+/* Animations */
+@keyframes kcHue{0%{background-position:0% 50%}100%{background-position:300% 50%}}
+
+/* Reduced motion: no animations */
+@media (prefers-reduced-motion: reduce){
+  .kc-materials-card::before{ animation:none !important; }
+}


### PR DESCRIPTION
## Summary
- add premium glass effect styles for materials card, grid, and chips

## Testing
- `php -l footer.php functions.php utils.php`


------
https://chatgpt.com/codex/tasks/task_e_68a943839e948328865551d1da9bc3c5