### PR TITLE
Add brand blue badge and button styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -816,3 +816,46 @@
   .kc-title::after,
   .kc-title .kc-underline::after{ animation: none !important; }
 }
+/* ===== Brand Blue (adjust here if needed) ===== */
+:root{
+  --kc-blue-1: #3b82f6; /* top */
+  --kc-blue-2: #2563eb; /* bottom */
+  --kc-blue-hover-1: #4f8ef9;
+  --kc-blue-hover-2: #2b6ae8;
+}
+
+/* Blue pill badges */
+.kc-badge--blue{
+  color:#fff;
+  background: linear-gradient(180deg, var(--kc-blue-1), var(--kc-blue-2));
+  border: 1px solid rgba(255,255,255,.18);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, .28);
+}
+.kc-badge--blue:focus-visible{
+  outline: none;
+  box-shadow:
+    0 0 0 3px rgba(255,255,255,.45),
+    0 6px 16px rgba(37,99,235,.28);
+}
+
+/* "View Colors" as blue button (overrides secondary look) */
+.kc-cta-secondary .kc-btn-blue{
+  color:#fff;
+  background: linear-gradient(180deg, var(--kc-blue-1), var(--kc-blue-2));
+  border: 1px solid rgba(255,255,255,.22);
+  box-shadow: 0 10px 26px rgba(37,99,235,.30);
+}
+.kc-cta-secondary .kc-btn-blue:hover,
+.kc-cta-secondary .kc-btn-blue:focus-visible{
+  background: linear-gradient(180deg, var(--kc-blue-hover-1), var(--kc-blue-hover-2));
+  transform: translateY(-2px);
+  border-color: rgba(255,255,255,.30);
+  box-shadow: 0 14px 34px rgba(37,99,235,.35);
+  outline: none;
+}
+
+/* Ensure text stays readable on dark backgrounds */
+.kc-cta-secondary .kc-btn-blue,
+.kc-badge--blue{
+  text-shadow: 0 1px 0 rgba(0,0,0,.18);
+}


### PR DESCRIPTION
## Summary
- add brand blue variables
- style blue badges and buttons with hover and focus states

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a95a78f3cc8328a55b40a639815c68