### PR TITLE
feat: load materials grid styles in editor

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -69,15 +69,28 @@ add_action( 'init', function () {
 
 /** ---------- END: Kadence Child Pattern Category ---------- */
 
-// Enqueue editor-only styles so the 3D ring carousel previews nicely in the editor
+// Enqueue editor-only styles so patterns preview correctly in the editor
 add_action('enqueue_block_editor_assets', function () {
-  $path = get_stylesheet_directory() . '/assets/css/editor.css';
-  if ( file_exists( $path ) ) {
+  $dir = get_stylesheet_directory();
+  $uri = get_stylesheet_directory_uri();
+
+  $editor = $dir . '/assets/css/editor.css';
+  if ( file_exists( $editor ) ) {
     wp_enqueue_style(
       'kadence-child-editor',
-      get_stylesheet_directory_uri() . '/assets/css/editor.css',
+      $uri . '/assets/css/editor.css',
       [],
-      filemtime( $path )
+      filemtime( $editor )
+    );
+  }
+
+  $mats = $dir . '/assets/css/es-mats.css';
+  if ( file_exists( $mats ) ) {
+    wp_enqueue_style(
+      'es-mats',
+      $uri . '/assets/css/es-mats.css',
+      [],
+      filemtime( $mats )
     );
   }
 });


### PR DESCRIPTION
## Summary
- ensure Materials Grid stylesheet enqueues in block editor for accurate preview
- pattern supports JS-gated animations, responsive breakpoints, reduced-motion, and IntersectionObserver fallback

## Testing
- `php -l functions.php`
- `php -l inc/patterns/es-mats-grid.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a9673a5d0c83288d52f758cec8dc34