### PR TITLE
Register hero patterns with static metadata

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -121,8 +121,16 @@ add_action('init', function () {
       ['label' => __('Elevated Surfaces', 'kadence-child')]
     );
   }
-  $pattern_file = get_stylesheet_directory() . '/inc/patterns/es-mats-grid.php';
-  if ( file_exists($pattern_file) ) {
-    require_once $pattern_file;
+  $patterns = [
+    'es-mats-grid.php',
+    'hero-intro.php',
+    'hero-ultimate.php',
+  ];
+
+  foreach ( $patterns as $pattern ) {
+    $pattern_file = get_stylesheet_directory() . '/inc/patterns/' . $pattern;
+    if ( file_exists( $pattern_file ) ) {
+      require_once $pattern_file;
+    }
   }
 });

--- a/inc/patterns/hero-intro.php
+++ b/inc/patterns/hero-intro.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Pattern: Hero Intro
+ */
+
+if ( ! function_exists( 'register_block_pattern' ) ) {
+    return;
+}
+
+ob_start();
+include get_theme_file_path( 'patterns/hero-intro.php' );
+$pattern_content = ob_get_clean();
+
+register_block_pattern(
+    'kadence-child/hero-intro',
+    [
+        'title'       => __( 'Hero Intro', 'kadence-child' ),
+        'description' => __( 'Simple hero intro section with heading and paragraph.', 'kadence-child' ),
+        'categories'  => [ 'kadence-child', 'text', 'featured' ],
+        'content'     => $pattern_content,
+    ]
+);

--- a/inc/patterns/hero-ultimate.php
+++ b/inc/patterns/hero-ultimate.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Pattern: Hero – Ultimate (Motion)
+ */
+
+if ( ! function_exists( 'register_block_pattern' ) ) {
+    return;
+}
+
+ob_start();
+include get_theme_file_path( 'patterns/hero-ultimate.php' );
+$pattern_content = ob_get_clean();
+
+register_block_pattern(
+    'kadence-child/hero-ultimate',
+    [
+        'title'       => __( 'Hero – Ultimate (Motion)', 'kadence-child' ),
+        'description' => __( 'Full-bleed hero with layered parallax, animated headline, and dual CTAs.', 'kadence-child' ),
+        'categories'  => [ 'kadence-child', 'featured' ],
+        'content'     => $pattern_content,
+    ]
+);

--- a/patterns/hero-intro.php
+++ b/patterns/hero-intro.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Title: <?php esc_html_e( 'Hero Intro', 'kadence-child' ); ?>
+ * Title: Hero Intro
  * Slug: kadence-child/hero-intro
  * Categories: kadence-child, text, featured
- * Description: <?php esc_html_e( 'Simple hero intro section with heading and paragraph.', 'kadence-child' ); ?>
+ * Description: Simple hero intro section with heading and paragraph.
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"60px","bottom":"60px","left":"20px","right":"20px"}}},"layout":{"type":"constrained"}} -->

--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Title: <?php esc_html_e( 'Hero – Ultimate (Motion)', 'kadence-child' ); ?>
+ * Title: Hero – Ultimate (Motion)
  * Slug: kadence-child/hero-ultimate
  * Categories: kadence-child, featured
- * Description: <?php esc_html_e( 'Full-bleed hero with layered parallax, animated headline, and dual CTAs.', 'kadence-child' ); ?>
+ * Description: Full-bleed hero with layered parallax, animated headline, and dual CTAs.
  */
 ?>
 <!-- wp:cover {"dimRatio":0,"isUserOverlayColor":true,"customGradient":"linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)","minHeight":45,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}}} -->


### PR DESCRIPTION
## Summary
- replace dynamic metadata with static strings for hero intro and hero ultimate patterns
- register hero intro and hero ultimate patterns in PHP for translation support
- load new pattern registrations during init

## Testing
- `php -l patterns/hero-intro.php`
- `php -l patterns/hero-ultimate.php`
- `php -l inc/patterns/hero-intro.php`
- `php -l inc/patterns/hero-ultimate.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a96eb8d30883289755b1aa989985eb