### PR TITLE
Register hero showcase carousel pattern

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -125,6 +125,7 @@ add_action('init', function () {
     'es-mats-grid.php',
     'hero-intro.php',
     'hero-ultimate.php',
+    'hero-showcase-carousel.php',
   ];
 
   foreach ( $patterns as $pattern ) {

--- a/inc/patterns/hero-showcase-carousel.php
+++ b/inc/patterns/hero-showcase-carousel.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Pattern: Hero — Showcase (with Carousel)
+ */
+
+if ( ! function_exists( 'register_block_pattern' ) ) {
+    return;
+}
+
+ob_start();
+include get_theme_file_path( 'patterns/hero-showcase-carousel.php' );
+$pattern_content = ob_get_clean();
+
+register_block_pattern(
+    'kadence-child/hero-showcase-carousel',
+    [
+        'title'       => __( 'Hero — Showcase (with Carousel)', 'kadence-child' ),
+        'description' => __( 'Hero layout featuring a showcase grid, CTA bar, and built-in carousel.', 'kadence-child' ),
+        'categories'  => [ 'kadence-child', 'featured' ],
+        'content'     => $pattern_content,
+    ]
+);


### PR DESCRIPTION
## Summary
- register Hero — Showcase (with Carousel) block pattern
- load the new pattern in `functions.php` so WordPress can register it

## Testing
- `php -l functions.php`
- `php -l inc/patterns/hero-showcase-carousel.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9709181cc83288789d62ce8473d0b