### PR TITLE
Guard pattern registration by checking WP block pattern API

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -115,12 +115,17 @@ add_action('wp_enqueue_scripts', function () {
 });
 
 add_action('init', function () {
+  if ( ! function_exists( 'register_block_pattern' ) ) {
+    return;
+  }
+
   if ( function_exists('register_block_pattern_category') ) {
     register_block_pattern_category(
       'elevated',
       ['label' => __('Elevated Surfaces', 'kadence-child')]
     );
   }
+
   $patterns = [
     'es-mats-grid.php',
     'hero-intro.php',

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -3,10 +3,6 @@
  * Pattern: Materials Grid (6 Cards, Hero + Mix)
  */
 
-if ( ! function_exists('register_block_pattern') ) {
-    return;
-}
-
 $pattern_content = <<<HTML
 <!-- wp:group {"tagName":"section","layout":{"type":"constrained"}} -->
 <section class="wp-block-group">

--- a/inc/patterns/hero-intro.php
+++ b/inc/patterns/hero-intro.php
@@ -3,10 +3,6 @@
  * Pattern: Hero Intro
  */
 
-if ( ! function_exists( 'register_block_pattern' ) ) {
-    return;
-}
-
 ob_start();
 include get_theme_file_path( 'patterns/hero-intro.php' );
 $pattern_content = ob_get_clean();

--- a/inc/patterns/hero-showcase-carousel.php
+++ b/inc/patterns/hero-showcase-carousel.php
@@ -3,10 +3,6 @@
  * Pattern: Hero — Showcase (with Carousel)
  */
 
-if ( ! function_exists( 'register_block_pattern' ) ) {
-    return;
-}
-
 ob_start();
 include get_theme_file_path( 'patterns/hero-showcase-carousel.php' );
 $pattern_content = ob_get_clean();

--- a/inc/patterns/hero-ultimate.php
+++ b/inc/patterns/hero-ultimate.php
@@ -3,10 +3,6 @@
  * Pattern: Hero – Ultimate (Motion)
  */
 
-if ( ! function_exists( 'register_block_pattern' ) ) {
-    return;
-}
-
 ob_start();
 include get_theme_file_path( 'patterns/hero-ultimate.php' );
 $pattern_content = ob_get_clean();


### PR DESCRIPTION
## Summary
- Check for `register_block_pattern` before requiring child-theme pattern files
- Drop early `register_block_pattern` checks inside pattern definitions

## Testing
- `php -l functions.php`
- `php -l inc/patterns/es-mats-grid.php`
- `php -l inc/patterns/hero-intro.php`
- `php -l inc/patterns/hero-ultimate.php`
- `php -l inc/patterns/hero-showcase-carousel.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab3e159e988328b4b09544eef14d44