### PR TITLE
Revamp materials grid pattern with tinted overlays

### DIFF
--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -14,7 +14,7 @@
   border-radius:18px; overflow:hidden; text-decoration:none; color:#fff; background:#000;
   box-shadow:0 8px 28px rgba(0,0,0,.35); isolation:isolate;
 }
-#es-mats .es-card img{ display:block; width:100%; height:100%; object-fit:cover; filter:saturate(1.02) contrast(1.02); }
+#es-mats .es-card img{ display:block; width:100%; height:100%; object-fit:cover; filter:saturate(1.02) contrast(1.02); transition:transform .6s ease; }
 
 /* Overlays */
 #es-mats .es-card::before{
@@ -27,19 +27,18 @@
   content:""; position:absolute; inset:-20% -40%;
   transform:skewX(-18deg) translateX(-120%);
   background:linear-gradient(90deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.35) 50%,rgba(255,255,255,0) 100%);
-  mix-blend-mode:soft-light; filter:blur(6px); opacity:.0; z-index:1; pointer-events:none;
+  mix-blend-mode:soft-light; filter:blur(6px); opacity:.0; z-index:3; pointer-events:none;
 }
 #es-mats .es-card._in::after{ animation:es-sheen .9s .25s ease forwards; }
 @keyframes es-sheen{ to{ transform:skewX(-18deg) translateX(120%); opacity:.55; } }
 
-/* Vertical tags */
-#es-mats .vtag{
-  position:absolute; left:10px; top:50%; transform:translateY(-50%) rotate(180deg);
-  writing-mode:vertical-rl; white-space:nowrap; line-height:1; background:#111; color:#fff;
-  border-radius:999px; padding:10px 9px; font-weight:800; letter-spacing:.6px;
-  box-shadow:0 6px 22px rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.15); z-index:2;
-}
-#es-mats .vtag.vtag--right{ left:auto; right:10px; }
+/* Tint layer and content */
+#es-mats .es-card .tint{ position:absolute; inset:0; background:rgba(4,20,47,.55); mix-blend-mode:multiply; z-index:1; transition:background .45s ease; }
+#es-mats .card-title{ position:absolute; left:18px; bottom:16px; font-weight:700; font-size:1.125rem; z-index:2; letter-spacing:.3px; }
+#es-mats .card-index{ position:absolute; top:10px; right:14px; font-size:2.5rem; font-weight:800; line-height:1; opacity:.15; z-index:2; transition:opacity .45s ease; }
+#es-mats .es-card:hover img{ transform:scale(1.05); }
+#es-mats .es-card:hover .tint{ background:rgba(4,20,47,.72); }
+#es-mats .es-card:hover .card-index{ opacity:.3; }
 
 /* Animation is opt-in (JS adds .es-animate) */
 #es-mats.es-animate .es-card{

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -8,17 +8,17 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
 $include_path = get_theme_file_path( 'patterns/es-mats-grid.php' );
 
 if ( file_exists( $include_path ) ) {
-	ob_start();
-	include $include_path;
-	$pattern_content = ob_get_clean();
+        ob_start();
+        include $include_path;
+        $pattern_content = ob_get_clean();
 } else {
-	$pattern_content = <<<HTML
+        $pattern_content = <<<HTML
 <!-- wp:group {"tagName":"section","layout":{"type":"constrained"}} -->
 <section class="wp-block-group">
 <!-- wp:html -->
@@ -28,37 +28,49 @@ if ( file_exists( $include_path ) ) {
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
     <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="vtag">Quartz</span>
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="vtag">Natural&nbsp;Stone</span>
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="vtag">Solid&nbsp;Surface</span>
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="vtag vtag--right">Ultra&nbsp;Compact</span>
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
     <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="vtag">Laminate</span>
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
     <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="vtag">Sinks</span>
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>
@@ -70,14 +82,14 @@ HTML;
 }
 
 if ( function_exists( 'register_block_pattern' ) ) {
-	register_block_pattern(
-		'kadence-child/es-mats-grid',
-		[
-			'title'       => __( 'Materials Grid (6 Cards, Hero + Mix)', 'kadence-child' ),
-			'description' => __( 'Six-card materials navigation grid with scroll-reveal animation and vertical tags.', 'kadence-child' ),
-			'categories'  => [ 'kadence-child', 'elevated' ],
-			'content'     => $pattern_content,
-			'inserter'    => true,
-		]
-	);
+        register_block_pattern(
+                'kadence-child/es-mats-grid',
+                [
+                        'title'       => __( 'Materials Grid (6 Cards, Hero + Mix)', 'kadence-child' ),
+                        'description' => __( 'Six-card materials navigation grid with scroll-reveal animation, tinted overlays, and numbered tiles.', 'kadence-child' ),
+                        'categories'  => [ 'kadence-child', 'elevated' ],
+                        'content'     => $pattern_content,
+                        'inserter'    => true,
+                ]
+        );
 }

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -3,7 +3,7 @@
  * Title: Materials Grid (6 Cards, Hero + Mix)
  * Slug: kadence-child/es-mats-grid
  * Categories: kadence-child, elevated
- * Description: Six-card materials navigation grid with scroll-reveal animation and vertical tags.
+ * Description: Six-card materials navigation grid with scroll-reveal animation, tinted overlays, and numbered tiles.
  */
 ?>
 <!-- wp:group {"tagName":"section","layout":{"type":"constrained"}} -->
@@ -15,37 +15,49 @@
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
     <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="vtag">Quartz</span>
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="vtag">Natural&nbsp;Stone</span>
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="vtag">Solid&nbsp;Surface</span>
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="vtag vtag--right">Ultra&nbsp;Compact</span>
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
     <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="vtag">Laminate</span>
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
     <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="vtag">Sinks</span>
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>


### PR DESCRIPTION
## Summary
- overhaul materials grid pattern with numbered tiles and tinted overlay
- add CSS hover effects for tint and image zoom
- sync fallback registration with updated markup and description

## Testing
- `php -l patterns/es-mats-grid.php`
- `php -l inc/patterns/es-mats-grid.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab48d9e4208328b478dd5c7b6199d1