### PR TITLE
Rebuild materials grid with sliding overlay labels

### DIFF
--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -97,4 +97,8 @@
 @media (prefers-reduced-motion:reduce){
   #es-mats.es-animate .es-card{ opacity:1!important; transform:none!important; transition:none!important; }
   #es-mats .es-card._in::after{ animation:none; }
+  #es-mats .es-card:hover img,
+  #es-mats .es-card:focus-visible img{ transform:none!important; transition:none!important; }
+  #es-mats .es-card:hover .card-label,
+  #es-mats .es-card:focus-visible .card-label{ background:rgba(0,0,0,.55)!important; transform:none!important; transition:none!important; }
 }

--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -42,10 +42,14 @@
   transform:translateY(0); transition:transform .45s ease, background .45s ease;
 }
 #es-mats .label-index{ font-weight:800; opacity:.65; }
-#es-mats .es-card:hover img{ transform:scale(1.05); }
-#es-mats .es-card:hover::before{ background:linear-gradient(180deg,rgba(0,0,0,.22) 0%,rgba(0,0,0,.60) 100%),
+#es-mats .es-card:hover img,
+#es-mats .es-card:focus-visible img{ transform:scale(1.05); }
+#es-mats .es-card:hover::before,
+#es-mats .es-card:focus-visible::before{ background:linear-gradient(180deg,rgba(0,0,0,.22) 0%,rgba(0,0,0,.60) 100%),
              radial-gradient(120% 100% at 110% -10%,rgba(255,255,255,.22),rgba(255,255,255,0) 45%); }
-#es-mats .es-card:hover .card-label{ background:rgba(0,0,0,.72); transform:translateY(-6px); }
+#es-mats .es-card:hover .card-label,
+#es-mats .es-card:focus-visible .card-label{ background:rgba(0,0,0,.72); transform:translateY(-6px); }
+#es-mats .es-card:focus-visible{ outline:2px solid rgba(255,255,255,.85); outline-offset:-2px; }
 
 /* Animation is opt-in (JS adds .es-animate) */
 #es-mats.es-animate .es-card{

--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -5,7 +5,7 @@
 #es-mats .es-grid{
   display:grid; gap:18px;
   grid-template-columns:1.35fr 1fr 1fr;
-  grid-template-rows:320px 260px 260px;
+  grid-template-rows:260px 260px 260px;
 }
 
 /* Card base */
@@ -14,32 +14,38 @@
   border-radius:18px; overflow:hidden; text-decoration:none; color:#fff; background:#000;
   box-shadow:0 8px 28px rgba(0,0,0,.35); isolation:isolate;
 }
-#es-mats .es-card img{ display:block; width:100%; height:100%; object-fit:cover; filter:saturate(1.02) contrast(1.02); }
+#es-mats .es-card img{ display:block; width:100%; height:100%; object-fit:cover; filter:saturate(1.02) contrast(1.02); transition:transform .6s ease; }
 
 /* Overlays */
 #es-mats .es-card::before{
   content:""; position:absolute; inset:0; z-index:0;
-  background:linear-gradient(180deg,rgba(0,0,0,.32) 0%,rgba(0,0,0,.50) 100%),
-             radial-gradient(120% 100% at 110% -10%,rgba(255,255,255,.18),rgba(255,255,255,0) 45%);
+  background:linear-gradient(180deg,rgba(0,0,0,.15) 0%,rgba(0,0,0,.45) 100%),
+             radial-gradient(120% 100% at 110% -10%,rgba(255,255,255,.15),rgba(255,255,255,0) 45%);
   pointer-events:none;
+  transition:background .45s ease;
 }
 #es-mats .es-card::after{
   content:""; position:absolute; inset:-20% -40%;
   transform:skewX(-18deg) translateX(-120%);
   background:linear-gradient(90deg,rgba(255,255,255,0) 0%,rgba(255,255,255,.35) 50%,rgba(255,255,255,0) 100%);
-  mix-blend-mode:soft-light; filter:blur(6px); opacity:.0; z-index:1; pointer-events:none;
+  mix-blend-mode:soft-light; filter:blur(6px); opacity:.0; z-index:3; pointer-events:none;
 }
 #es-mats .es-card._in::after{ animation:es-sheen .9s .25s ease forwards; }
 @keyframes es-sheen{ to{ transform:skewX(-18deg) translateX(120%); opacity:.55; } }
 
-/* Vertical tags */
-#es-mats .vtag{
-  position:absolute; left:10px; top:50%; transform:translateY(-50%) rotate(180deg);
-  writing-mode:vertical-rl; white-space:nowrap; line-height:1; background:#111; color:#fff;
-  border-radius:999px; padding:10px 9px; font-weight:800; letter-spacing:.6px;
-  box-shadow:0 6px 22px rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.15); z-index:2;
+/* Label overlay */
+#es-mats .card-label{
+  position:absolute; left:0; right:0; bottom:0; z-index:2;
+  display:flex; justify-content:space-between; align-items:center;
+  padding:14px 18px; background:rgba(0,0,0,.55);
+  font-weight:700; font-size:1.125rem; letter-spacing:.3px;
+  transform:translateY(0); transition:transform .45s ease, background .45s ease;
 }
-#es-mats .vtag.vtag--right{ left:auto; right:10px; }
+#es-mats .label-index{ font-weight:800; opacity:.65; }
+#es-mats .es-card:hover img{ transform:scale(1.05); }
+#es-mats .es-card:hover::before{ background:linear-gradient(180deg,rgba(0,0,0,.22) 0%,rgba(0,0,0,.60) 100%),
+             radial-gradient(120% 100% at 110% -10%,rgba(255,255,255,.22),rgba(255,255,255,0) 45%); }
+#es-mats .es-card:hover .card-label{ background:rgba(0,0,0,.72); transform:translateY(-6px); }
 
 /* Animation is opt-in (JS adds .es-animate) */
 #es-mats.es-animate .es-card{

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -26,40 +26,40 @@ if ( file_exists( $include_path ) ) {
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index">01</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+        <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+      </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index">02</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+        <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+      </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index">03</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+        <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+      </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index">04</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+        <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+      </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index">05</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+        <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+      </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index">06</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+        <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+      </a>
 
   </div>
 </div>

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -8,17 +8,17 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
 $include_path = get_theme_file_path( 'patterns/es-mats-grid.php' );
 
 if ( file_exists( $include_path ) ) {
-	ob_start();
-	include $include_path;
-	$pattern_content = ob_get_clean();
+        ob_start();
+        include $include_path;
+        $pattern_content = ob_get_clean();
 } else {
-	$pattern_content = <<<HTML
+        $pattern_content = <<<HTML
 <!-- wp:group {"tagName":"section","layout":{"type":"constrained"}} -->
 <section class="wp-block-group">
 <!-- wp:html -->
@@ -28,37 +28,37 @@ if ( file_exists( $include_path ) ) {
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
     <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="vtag">Quartz</span>
+      <span class="card-label"><span>Quartz</span><span class="label-index">01</span></span>
     </a>
 
     <!-- NATURAL STONE -->
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="vtag">Natural&nbsp;Stone</span>
+      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index">02</span></span>
     </a>
 
     <!-- SOLID SURFACE -->
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="vtag">Solid&nbsp;Surface</span>
+      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index">03</span></span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="vtag vtag--right">Ultra&nbsp;Compact</span>
+      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index">04</span></span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
     <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="vtag">Laminate</span>
+      <span class="card-label"><span>Laminate</span><span class="label-index">05</span></span>
     </a>
 
     <!-- SINKS (bottom-right) -->
     <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="vtag">Sinks</span>
+      <span class="card-label"><span>Sinks</span><span class="label-index">06</span></span>
     </a>
 
   </div>
@@ -70,14 +70,14 @@ HTML;
 }
 
 if ( function_exists( 'register_block_pattern' ) ) {
-	register_block_pattern(
-		'kadence-child/es-mats-grid',
-		[
-			'title'       => __( 'Materials Grid (6 Cards, Hero + Mix)', 'kadence-child' ),
-			'description' => __( 'Six-card materials navigation grid with scroll-reveal animation and vertical tags.', 'kadence-child' ),
-			'categories'  => [ 'kadence-child', 'elevated' ],
-			'content'     => $pattern_content,
-			'inserter'    => true,
-		]
-	);
+        register_block_pattern(
+                'kadence-child/es-mats-grid',
+                [
+                        'title'       => __( 'Materials Grid (6 Cards, Hero + Mix)', 'kadence-child' ),
+                        'description' => __( 'Six-card materials navigation grid with aligned images, sliding overlays, and hover motion.', 'kadence-child' ),
+                        'categories'  => [ 'kadence-child', 'elevated' ],
+                        'content'     => $pattern_content,
+                        'inserter'    => true,
+                ]
+        );
 }

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -13,40 +13,40 @@
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index">01</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+        <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+      </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index">02</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+        <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+      </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index">03</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+        <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+      </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index">04</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+        <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+      </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index">05</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+        <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+      </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
-      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index">06</span></span>
-    </a>
+      <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
+        <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+        <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+      </a>
 
   </div>
 </div>

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -3,7 +3,7 @@
  * Title: Materials Grid (6 Cards, Hero + Mix)
  * Slug: kadence-child/es-mats-grid
  * Categories: kadence-child, elevated
- * Description: Six-card materials navigation grid with scroll-reveal animation and vertical tags.
+ * Description: Six-card materials navigation grid with aligned images, sliding overlays, and hover motion.
  */
 ?>
 <!-- wp:group {"tagName":"section","layout":{"type":"constrained"}} -->
@@ -15,37 +15,37 @@
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
     <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="vtag">Quartz</span>
+      <span class="card-label"><span>Quartz</span><span class="label-index">01</span></span>
     </a>
 
     <!-- NATURAL STONE -->
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="vtag">Natural&nbsp;Stone</span>
+      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index">02</span></span>
     </a>
 
     <!-- SOLID SURFACE -->
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="vtag">Solid&nbsp;Surface</span>
+      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index">03</span></span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="vtag vtag--right">Ultra&nbsp;Compact</span>
+      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index">04</span></span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
     <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="vtag">Laminate</span>
+      <span class="card-label"><span>Laminate</span><span class="label-index">05</span></span>
     </a>
 
     <!-- SINKS (bottom-right) -->
     <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="vtag">Sinks</span>
+      <span class="card-label"><span>Sinks</span><span class="label-index">06</span></span>
     </a>
 
   </div>


### PR DESCRIPTION
## Summary
- rebuild materials grid markup with bottom overlay labels and index numbers
- revamp CSS for uniform card heights, sliding overlay motion, and hover tint
- align fallback registration with updated structure and description

## Testing
- `php -l patterns/es-mats-grid.php`
- `php -l inc/patterns/es-mats-grid.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab48d9e4208328b478dd5c7b6199d1