### PR TITLE
Fix material grid markup and styles

### DIFF
--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -1,5 +1,3 @@
-FILE: wp-content/themes/kadence-child/assets/css/es-mats-grid.css
-```css
 /* ---- Materials Grid (ES) ---- */
 #es-mats { max-width:1440px; margin:0 auto; padding:6px; color:#fff; font-family:inherit; }
 

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -1,5 +1,3 @@
-FILE: wp-content/themes/kadence-child/inc/patterns-es-mats-grid.php
-```php
 <?php
 /**
  * Pattern: Materials Grid (6 Cards, Hero + Mix)

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -1,5 +1,3 @@
-FILE: wp-content/themes/kadence-child/patterns/es-mats-grid.php
-```php
 <?php
 /**
  * Title: Materials Grid (6 Cards, Hero + Mix)


### PR DESCRIPTION
## Summary
- strip leftover markdown markers from Materials Grid pattern and fallback
- clean Materials Grid stylesheet header for valid CSS

## Testing
- `php -l patterns/es-mats-grid.php`
- `php -l inc/patterns/es-mats-grid.php`
- `npx --yes stylelint assets/css/es-mats.css` *(fails: 403 Forbidden)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6119edb88328848aff2960d0ea9b