### PR TITLE
Refactor materials grid pattern markup

### DIFF
--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -26,39 +26,51 @@ if ( file_exists( $include_path ) ) {
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -13,39 +13,51 @@
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>


### PR DESCRIPTION
## Summary
- simplify materials grid pattern markup
- introduce tint overlay with separate title and index elements
- align fallback pattern registration with new markup

## Testing
- `php -l inc/patterns/es-mats-grid.php`
- `php -l patterns/es-mats-grid.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab638df8f08328be170fcd8741c848