### PR TITLE
Refactor materials grid pattern markup

### DIFF
--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -35,15 +35,20 @@
 #es-mats .es-card._in::after{ animation:es-sheen .9s .25s ease forwards; }
 @keyframes es-sheen{ to{ transform:skewX(-18deg) translateX(120%); opacity:.55; } }
 
-/* Label overlay (chosen variant) */
-#es-mats .card-label{
-  position:absolute; left:0; right:0; bottom:0; z-index:2;
-  display:flex; justify-content:space-between; align-items:center;
-  padding:14px 18px; background:rgba(0,0,0,.55);
-  font-weight:700; font-size:1.125rem; letter-spacing:.3px;
-  transform:translateY(0); transition:transform .45s ease, background .45s ease;
+/* Overlay tint and labels */
+#es-mats .tint{
+  position:absolute; inset:0; z-index:1;
+  background:rgba(0,0,0,.35);
+  pointer-events:none; transition:background .45s ease;
 }
-#es-mats .label-index{ font-weight:800; opacity:.65; }
+#es-mats .card-title,
+#es-mats .card-index{
+  position:absolute; bottom:14px; z-index:2;
+  font-weight:700; font-size:1.125rem; letter-spacing:.3px;
+  transform:translateY(0); pointer-events:none; transition:transform .45s ease;
+}
+#es-mats .card-title{ left:18px; }
+#es-mats .card-index{ right:18px; font-weight:800; opacity:.65; }
 
 /* Hover / focus */
 #es-mats .es-card:hover img,
@@ -53,8 +58,12 @@
   background:linear-gradient(180deg,rgba(0,0,0,.22) 0%,rgba(0,0,0,.60) 100%),
              radial-gradient(120% 100% at 110% -10%,rgba(255,255,255,.22),rgba(255,255,255,0) 45%);
 }
-#es-mats .es-card:hover .card-label,
-#es-mats .es-card:focus-visible .card-label{ background:rgba(0,0,0,.72); transform:translateY(-6px); }
+#es-mats .es-card:hover .tint,
+#es-mats .es-card:focus-visible .tint{ background:rgba(0,0,0,.55); }
+#es-mats .es-card:hover .card-title,
+#es-mats .es-card:hover .card-index,
+#es-mats .es-card:focus-visible .card-title,
+#es-mats .es-card:focus-visible .card-index{ transform:translateY(-6px); }
 #es-mats .es-card:focus-visible{ outline:2px solid rgba(255,255,255,.85); outline-offset:-2px; }
 
 /* Animation is opt-in (JS adds .es-animate) */

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -26,39 +26,51 @@ if ( file_exists( $include_path ) ) {
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -13,39 +13,51 @@
   <div class="es-grid">
 
     <!-- QUARTZ (hero: col 1, rows 1–2) -->
-    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left" aria-label="Quartz">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
-      <span class="card-label"><span>Quartz</span><span class="label-index" aria-hidden="true">01</span></span>
+    <a href="https://elevatedcountertopexperts.com/quartz/" class="es-card cell-quartz" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/VIATERA-Residential-Taj-Crema-kitchen-Mid2-scaled.jpg" alt="Quartz countertop">
+      <span class="tint"></span>
+      <span class="card-title">Quartz</span>
+      <span class="card-index">01</span>
     </a>
 
     <!-- NATURAL STONE -->
-    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up" aria-label="Natural Stone">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
-      <span class="card-label"><span>Natural&nbsp;Stone</span><span class="label-index" aria-hidden="true">02</span></span>
+    <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
+      <span class="tint"></span>
+      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-index">02</span>
     </a>
 
     <!-- SOLID SURFACE -->
-    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down" aria-label="Solid Surface">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
-      <span class="card-label"><span>Solid&nbsp;Surface</span><span class="label-index" aria-hidden="true">03</span></span>
+    <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
+      <span class="tint"></span>
+      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-index">03</span>
     </a>
 
     <!-- ULTRA COMPACT (wide middle) -->
-    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right" aria-label="Ultra Compact">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
-      <span class="card-label"><span>Ultra&nbsp;Compact</span><span class="label-index" aria-hidden="true">04</span></span>
+    <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
+      <span class="tint"></span>
+      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-index">04</span>
     </a>
 
     <!-- LAMINATE (bottom-left wide) -->
-    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up" aria-label="Laminate">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
-      <span class="card-label"><span>Laminate</span><span class="label-index" aria-hidden="true">05</span></span>
+    <a href="https://elevatedcountertopexperts.com/laminate/" class="es-card cell-laminate" data-dir="up">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-7404-Neapolitan-Stone-3-scaled_4aaa1f1a-c749-4986-97ce-57f9ddcdcf1b_1080x.webp" alt="Laminate countertop">
+      <span class="tint"></span>
+      <span class="card-title">Laminate</span>
+      <span class="card-index">05</span>
     </a>
 
     <!-- SINKS (bottom-right) -->
-    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left" aria-label="Sinks">
-      <img loading="lazy" decoding="async" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
-      <span class="card-label"><span>Sinks</span><span class="label-index" aria-hidden="true">06</span></span>
+    <a href="https://elevatedcountertopexperts.com/sinks/" class="es-card cell-sinks" data-dir="left">
+      <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Undermount-SInk-Karran.jpg" alt="Kitchen sinks">
+      <span class="tint"></span>
+      <span class="card-title">Sinks</span>
+      <span class="card-index">06</span>
     </a>
 
   </div>


### PR DESCRIPTION
## Summary
- simplify materials grid pattern markup
- introduce tint overlay with separate title and index elements
- align fallback pattern registration with new markup
- style tint and label elements for proper layout and hover effects

## Testing
- `php -l inc/patterns/es-mats-grid.php`
- `php -l patterns/es-mats-grid.php`
- `npx stylelint assets/css/es-mats.css` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab638df8f08328be170fcd8741c848