### PR TITLE
Remove nbsp from materials grid card titles

### DIFF
--- a/assets/css/es-mats.css
+++ b/assets/css/es-mats.css
@@ -44,7 +44,7 @@
   font-weight:700; font-size:1.125rem; letter-spacing:.3px;
   transform:translateY(0); pointer-events:none; transition:transform .45s ease;
 }
-#es-mats .card-title{ left:18px; }
+#es-mats .card-title{ left:18px; white-space:nowrap; }
 #es-mats .card-index{ right:18px; font-weight:800; opacity:.65; }
 
 /* Hover / focus */

--- a/inc/patterns/es-mats-grid.php
+++ b/inc/patterns/es-mats-grid.php
@@ -37,7 +37,7 @@ if ( file_exists( $include_path ) ) {
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
       <span class="tint"></span>
-      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-title">Natural Stone</span>
       <span class="card-index">02</span>
     </a>
 
@@ -45,7 +45,7 @@ if ( file_exists( $include_path ) ) {
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
       <span class="tint"></span>
-      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-title">Solid Surface</span>
       <span class="card-index">03</span>
     </a>
 
@@ -53,7 +53,7 @@ if ( file_exists( $include_path ) ) {
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
       <span class="tint"></span>
-      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-title">Ultra Compact</span>
       <span class="card-index">04</span>
     </a>
 

--- a/patterns/es-mats-grid.php
+++ b/patterns/es-mats-grid.php
@@ -24,7 +24,7 @@
     <a href="https://elevatedcountertopexperts.com/natural-stone/" class="es-card cell-ns" data-dir="up">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vertical-Application-of-Natural-Stone-Kitchen-Lakewood-CO-1-1.jpeg" alt="Natural stone countertop">
       <span class="tint"></span>
-      <span class="card-title">Natural&nbsp;Stone</span>
+      <span class="card-title">Natural Stone</span>
       <span class="card-index">02</span>
     </a>
 
@@ -32,7 +32,7 @@
     <a href="https://elevatedcountertopexperts.com/solid-surface/" class="es-card cell-solid" data-dir="down">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Solid-Surface-1.jpg" alt="Solid surface countertop">
       <span class="tint"></span>
-      <span class="card-title">Solid&nbsp;Surface</span>
+      <span class="card-title">Solid Surface</span>
       <span class="card-index">03</span>
     </a>
 
@@ -40,7 +40,7 @@
     <a href="https://elevatedcountertopexperts.com/ultra-compact/" class="es-card cell-ultra" data-dir="right">
       <img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-Countertops.avif" alt="Ultra compact surface">
       <span class="tint"></span>
-      <span class="card-title">Ultra&nbsp;Compact</span>
+      <span class="card-title">Ultra Compact</span>
       <span class="card-index">04</span>
     </a>
 


### PR DESCRIPTION
## Summary
- Replace `&nbsp;` with plain strings in materials grid card titles
- Add CSS `white-space: nowrap` to keep titles unbroken

## Testing
- `php -l patterns/es-mats-grid.php`
- `php -l inc/patterns/es-mats-grid.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6fcf4b748328a1a9557a2166f33f