### PR TITLE
Force https for local media and tidy hero showcase pattern

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -114,3 +114,14 @@ add_action('init', function () {
     }
   }
 });
+
+// Force local media and content URLs to use HTTPS to avoid mixed-content warnings
+add_filter( 'wp_get_attachment_url', function ( $url ) {
+  return set_url_scheme( $url, 'https' );
+} );
+
+add_filter( 'the_content', function ( $content ) {
+  $home_http  = set_url_scheme( home_url(), 'http' );
+  $home_https = set_url_scheme( home_url(), 'https' );
+  return str_replace( $home_http, $home_https, $content );
+} );

--- a/patterns/hero-showcase-carousel.php
+++ b/patterns/hero-showcase-carousel.php
@@ -6,14 +6,13 @@
  */
 ?>
 
-<!-- wp:group {"tagName":"section","className":"kc-hero-showcase","layout":{"type":"constrained"}} -->
-<section class="kc-hero-showcase" aria-label="Premium Countertops Hero">
-  <div class="kc-hero-bg" style="--hero-bg:url('BACKGROUND_IMAGE_URL');"></div>
+<!-- wp:html -->
+<section class="wp-block-group kc-hero-showcase" aria-label="Premium Countertops Hero">
+  <div class="kc-hero-bg" style="--hero-bg:url('https://example.com/path/to/hero-image.jpg');"></div>
   <div class="kc-hero-scrim"></div>
 
   <div class="kc-hero-wrap">
     <div class="kc-hero-grid">
-      <!-- LEFT -->
       <header class="kc-hero-left">
         <p class="kc-eyebrow">Countertops for every space · <span class="nowrap">Wisconsin</span></p>
         <h1 class="kc-heading">
@@ -32,7 +31,6 @@
         </nav>
       </header>
 
-      <!-- RIGHT -->
       <aside class="kc-hero-right" aria-label="<?php esc_attr_e( 'Browse categories', 'kadence-child' ); ?>">
         <a class="kc-card" href="/quartz"><span class="kc-card-title"><?php esc_html_e( 'Quartz', 'kadence-child' ); ?></span></a>
         <a class="kc-card" href="/natural-stone"><span class="kc-card-title"><?php esc_html_e( 'Natural Stone', 'kadence-child' ); ?></span></a>
@@ -43,17 +41,14 @@
       </aside>
     </div>
 
-    <!-- CTA BAR -->
     <div class="kc-cta-bar" role="region" aria-label="Quick actions">
       <a class="kc-pill" href="/free-quote">Schedule Your Free Quote</a>
       <a class="kc-pill kc-pill--ghost" href="/color-samples">Explore Countertop Colors</a>
     </div>
 
-    <!-- Reuse the existing, working carousel pattern -->
-    <!-- IMPORTANT: This slug must match the existing pattern. -->
     <!-- wp:pattern {"slug":"kadence-child/carousel-3d-ring"} /-->
 
   </div>
 </section>
-<!-- /wp:group -->
+<!-- /wp:html -->
 

--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -8,30 +8,25 @@
 ?>
 <!-- wp:cover {"dimRatio":0,"isUserOverlayColor":true,"customGradient":"linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)","minHeight":45,"minHeightUnit":"vh","align":"full","className":"kc-hero-ultimate","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}}} -->
 <div class="wp-block-cover alignfull kc-hero-ultimate" style="padding-top:40px;padding-bottom:40px;min-height:45vh">
-  <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim" style="background:linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)"></span>
-  <img class="wp-block-cover__image-background" alt="" data-object-fit="cover" src="http://elevatedcountertopexperts.com/wp-content/uploads/2025/08/AdobeStock_884069741-scaled.jpeg"/>
+  <span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim has-background-gradient" style="background:linear-gradient(90deg,rgba(0,0,0,0.75) 0%,rgba(0,0,0,0) 100%)"></span>
+  <img class="wp-block-cover__image-background" alt="" data-object-fit="cover" src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/AdobeStock_884069741-scaled.jpeg"/>
   <div class="wp-block-cover__inner-container">
     <!-- wp:group {"layout":{"type":"constrained","contentSize":"1900px"}} -->
     <div class="wp-block-group kc-hero-wrap">
-      <!-- Decorative floating chips -->
       <div class="kc-float a"></div>
       <div class="kc-float b"></div>
 
       <!-- wp:group {"className":"kc-hero-flex","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"nowrap"}} -->
       <div class="wp-block-group kc-hero-flex">
-        <!-- Left column -->
         <!-- wp:group {"className":"kc-hero-left","layout":{"type":"flex","orientation":"vertical"}} -->
         <div class="wp-block-group kc-hero-left">
-          <!-- HERO HEADLINE CLUSTER -->
           <!-- wp:group {"className":"kc-hero-head"} -->
           <div class="wp-block-group kc-hero-head">
 
-            <!-- Eyebrow -->
             <!-- wp:paragraph {"className":"kc-eyebrow"} -->
             <p class="kc-eyebrow"><?php esc_html_e( 'Countertops • Fabrication • Installation', 'kadence-child' ); ?></p>
             <!-- /wp:paragraph -->
 
-            <!-- Small badges -->
             <!-- wp:html -->
             <div class="kc-badges">
               <span class="kc-badge kc-badge--blue"><?php esc_html_e( 'Statewide — Wisconsin', 'kadence-child' ); ?></span>
@@ -39,7 +34,6 @@
             </div>
             <!-- /wp:html -->
 
-            <!-- Title -->
             <!-- wp:heading {"level":1,"className":"kc-title"} -->
             <h1 class="kc-title">
               <?php
@@ -56,12 +50,10 @@
             </h1>
             <!-- /wp:heading -->
 
-            <!-- Subcopy -->
             <!-- wp:paragraph {"className":"kc-sub"} -->
             <p class="kc-sub"><?php esc_html_e( 'Quartz, natural stone, solid surface, and laminate—crafted, delivered, and installed statewide with 5-star care.', 'kadence-child' ); ?></p>
             <!-- /wp:paragraph -->
 
-            <!-- CTAs -->
             <!-- wp:buttons {"className":"kc-hero-ctas","layout":{"type":"flex","justifyContent":"left"}} -->
             <div class="wp-block-buttons kc-hero-ctas">
               <!-- wp:button {"className":"is-style-fill kc-cta-primary"} -->
@@ -70,9 +62,9 @@
               </div>
               <!-- /wp:button -->
 
-              <!-- wp:button {"className":"is-style-outline kc-cta-secondary"} -->
-              <div class="wp-block-button kc-cta-secondary">
-                <a class="wp-block-button__link wp-element-button kc-btn-blue" href="/color-samples/"><?php esc_html_e( 'View Colors', 'kadence-child' ); ?></a>
+              <!-- wp:button {"className":"is-style-outline kc-cta-secondary kc-btn-blue"} -->
+              <div class="wp-block-button kc-cta-secondary kc-btn-blue">
+                <a class="wp-block-button__link wp-element-button" href="/color-samples/"><?php esc_html_e( 'View Colors', 'kadence-child' ); ?></a>
               </div>
               <!-- /wp:button -->
             </div>
@@ -83,10 +75,8 @@
         </div>
         <!-- /wp:group -->
 
-        <!-- Right column -->
         <!-- wp:group {"className":"kc-hero-right","layout":{"type":"flex","orientation":"vertical"}} -->
         <div class="wp-block-group kc-hero-right">
-          <!-- Materials Menu -->
           <!-- wp:group {"className":"kc-materials-card"} -->
           <div class="wp-block-group kc-materials-card" role="region" aria-label="<?php esc_attr_e( 'Browse materials', 'kadence-child' ); ?>">
             <!-- wp:heading {"level":3,"className":"kc-materials-heading"} -->

--- a/style.css
+++ b/style.css
@@ -844,14 +844,14 @@
 }
 
 /* "View Colors" as blue button (overrides secondary look) */
-.kc-cta-secondary .kc-btn-blue{
+.kc-cta-secondary.kc-btn-blue .wp-block-button__link{
   color:#fff;
   background: linear-gradient(180deg, var(--kc-blue-1), var(--kc-blue-2));
   border: 1px solid rgba(255,255,255,.22);
   box-shadow: 0 10px 26px rgba(37,99,235,.30);
 }
-.kc-cta-secondary .kc-btn-blue:hover,
-.kc-cta-secondary .kc-btn-blue:focus-visible{
+.kc-cta-secondary.kc-btn-blue .wp-block-button__link:hover,
+.kc-cta-secondary.kc-btn-blue .wp-block-button__link:focus-visible{
   background: linear-gradient(180deg, var(--kc-blue-hover-1), var(--kc-blue-hover-2));
   transform: translateY(-2px);
   border-color: rgba(255,255,255,.30);
@@ -860,7 +860,7 @@
 }
 
 /* Ensure text stays readable on dark backgrounds */
-.kc-cta-secondary .kc-btn-blue,
+.kc-cta-secondary.kc-btn-blue .wp-block-button__link,
 .kc-badge--blue{
   text-shadow: 0 1px 0 rgba(0,0,0,.18);
 }


### PR DESCRIPTION
## Summary
- Force local media and content URLs to use HTTPS
- Give Hero Showcase pattern a `wp-block-group` class and HTTPS placeholder image

## Testing
- `php -l functions.php`
- `php -l patterns/hero-showcase-carousel.php`


------
https://chatgpt.com/codex/tasks/task_e_68ab89227c3c83289827eb63de92deb8