### PR TITLE
Adjust es-card images to fill tiles

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@
   backface-visibility:hidden;
   /* JS sets rotateY(-currentAngle - theta) so faces viewer */
 }
-.es-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; }
+.es-card img{ display:block; width:100%; height:100%; object-fit:cover; }
 
 /* ===== No-JS fallbacks ===== */
 .es-fallback{


### PR DESCRIPTION
## Summary
- make `.es-card` images cover their tiles by setting width/height to 100% and `object-fit: cover`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac523a84c8832896a94404a84b22c2