### PR TITLE
Adjust es-card images and widen carousel ring to 1900px

### DIFF
--- a/patterns/carousel-3d-ring.php
+++ b/patterns/carousel-3d-ring.php
@@ -11,7 +11,7 @@
  * - data-tilt   : tilt angle in degrees (defaults to 8)
  */
 ?>
-<!-- wp:group {"align":"full","className":"kc-ring-wrap","style":{"spacing":{"padding":{"top":"36px","bottom":"36px"}}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
+<!-- wp:group {"align":"full","className":"kc-ring-wrap","style":{"spacing":{"padding":{"top":"36px","bottom":"36px"}}},"layout":{"type":"constrained","contentSize":"1900px"}} -->
 <div class="wp-block-group alignfull kc-ring-wrap">
   <!-- wp:html -->
     <div class="es-stage">

--- a/style.css
+++ b/style.css
@@ -91,7 +91,7 @@
   backface-visibility:hidden;
   /* JS sets rotateY(-currentAngle - theta) so faces viewer */
 }
-.es-card img{ display:block; max-width:85%; max-height:75%; height:auto; object-fit:contain; }
+.es-card img{ display:block; width:100%; height:100%; object-fit:cover; }
 
 /* ===== No-JS fallbacks ===== */
 .es-fallback{


### PR DESCRIPTION
## Summary
- make `.es-card` images cover their tiles by setting width/height to 100% and `object-fit: cover`
- expand the 3D logo carousel section to 1900px content width

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ac523a84c8832896a94404a84b22c2