### PR TITLE
Add custom header template and assets

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -1,0 +1,6 @@
+/* Styles for the fancy header */
+.fancy-header {
+  background: #f5f5f5;
+  padding: 1rem;
+  text-align: center;
+}

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,0 +1,4 @@
+/* Header interaction scripts */
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('Fancy header script loaded');
+});

--- a/functions.php
+++ b/functions.php
@@ -35,17 +35,40 @@ add_action('wp_enqueue_scripts', function () {
   );
 
   // ---- Child JS (loads only if the file exists) ----
-    $child_js_file = get_stylesheet_directory() . '/assets/child.js';
-    if ( file_exists( $child_js_file ) ) {
-      wp_enqueue_script(
-        'kadence-child-js',
-        get_stylesheet_directory_uri() . '/assets/child.js',
-        [],                                   // Add deps here if you ever need (e.g., ['jquery'])
-        filemtime( $child_js_file ),          // Cache-bust when file changes
-        true                                  // Load in footer
-      );
-    }
-  });
+  $child_js_file = get_stylesheet_directory() . '/assets/child.js';
+  if ( file_exists( $child_js_file ) ) {
+    wp_enqueue_script(
+      'kadence-child-js',
+      get_stylesheet_directory_uri() . '/assets/child.js',
+      [],                                   // Add deps here if you ever need (e.g., ['jquery'])
+      filemtime( $child_js_file ),          // Cache-bust when file changes
+      true                                  // Load in footer
+    );
+  }
+
+  // ---- Header CSS ----
+  $header_css = get_stylesheet_directory() . '/assets/css/header.css';
+  if ( file_exists( $header_css ) ) {
+    wp_enqueue_style(
+      'kadence-child-header',
+      get_stylesheet_directory_uri() . '/assets/css/header.css',
+      [],
+      filemtime( $header_css )
+    );
+  }
+
+  // ---- Header JS ----
+  $header_js = get_stylesheet_directory() . '/assets/js/header.js';
+  if ( file_exists( $header_js ) ) {
+    wp_enqueue_script(
+      'kadence-child-header',
+      get_stylesheet_directory_uri() . '/assets/js/header.js',
+      [],
+      filemtime( $header_js ),
+      true
+    );
+  }
+});
 
 add_action( 'wp_enqueue_scripts', function () {
   wp_enqueue_script(

--- a/header.php
+++ b/header.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Theme header
+ *
+ * @package KadenceChild
+ */
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+  <meta charset="<?php bloginfo( 'charset' ); ?>" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<?php get_template_part( 'template-parts/header', 'fancy' ); ?>

--- a/template-parts/header-fancy.php
+++ b/template-parts/header-fancy.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Fancy header template.
+ *
+ * @package KadenceChild
+ */
+?>
+<header class="fancy-header">
+  <h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a></h1>
+</header>


### PR DESCRIPTION
## Summary
- implement custom `header.php` that loads a fancy header template part
- add `header-fancy.php` template along with CSS and JS assets
- enqueue new header assets in `functions.php`

## Testing
- `php -l header.php`
- `php -l template-parts/header-fancy.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68acc1b920c88328a8c0dc4fb3fa3759