### PR TITLE
Load fancy header via minimal shell

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,16 +1,17 @@
 <?php
 /**
- * Theme header
- *
- * @package KadenceChild
+ * Child Theme Header Loader
+ * Uses a custom header template while preserving Kadence structure.
  */
-?><!doctype html>
+if ( ! defined( 'ABSPATH' ) ) { exit; }
+?><!DOCTYPE html>
 <html <?php language_attributes(); ?>>
 <head>
-  <meta charset="<?php bloginfo( 'charset' ); ?>" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <?php wp_head(); ?>
+<meta charset="<?php bloginfo( 'charset' ); ?>" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<?php wp_head(); ?>
 </head>
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
-<?php get_template_part( 'template-parts/header', 'fancy' ); ?>
+
+<?php get_template_part( 'template-parts/header-fancy' ); ?>


### PR DESCRIPTION
## Summary
- Replace child theme header with minimal loader that outputs custom fancy header while retaining Kadence/WordPress hooks.

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68acc31f61508328af330599670bf7fb