### PR TITLE
Improve header interactivity

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,4 +1,5 @@
 document.body.classList.remove('no-js');
+document.body.classList.add('js');
 
 // toggle verbose logging
 const DEBUG = false;

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,4 +1,57 @@
-/* Header interaction scripts */
+/**
+ * Interactivity for the fancy header.
+ * Handles sticky behaviour, mobile drawer and search overlay.
+ */
+
 document.addEventListener('DOMContentLoaded', () => {
-  console.log('Fancy header script loaded');
+  const body   = document.body;
+  const header = document.getElementById('kc-header');
+  const drawer = document.getElementById('kc-drawer');
+  const burger = document.querySelector('.kc-burger');
+  const drawerClose = document.querySelector('.kc-drawer-close');
+  const searchOverlay = document.querySelector('.kc-search');
+  const searchBtn   = document.querySelector('.kc-search-btn');
+  const searchClose = document.querySelector('.kc-search-close');
+
+  // Remove no-js marker and add js helper class
+  body.classList.remove('no-js');
+  body.classList.add('js');
+
+  // Sticky header toggle
+  const offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
+  const onScroll = () => {
+    if (window.scrollY > offset) {
+      header.classList.add('kc--stuck');
+    } else {
+      header.classList.remove('kc--stuck');
+    }
+  };
+  window.addEventListener('scroll', onScroll, {passive: true});
+  onScroll();
+
+  // Drawer helpers
+  const toggleDrawer = (open) => {
+    if (!drawer) return;
+    drawer.setAttribute('aria-hidden', String(!open));
+    burger?.setAttribute('aria-expanded', String(open));
+    if (open) {
+      drawer.querySelector('a,button')?.focus();
+    }
+  };
+  burger?.addEventListener('click', () => toggleDrawer(true));
+  drawerClose?.addEventListener('click', () => toggleDrawer(false));
+  drawer?.addEventListener('click', (e) => {
+    if (e.target === drawer) toggleDrawer(false);
+  });
+
+  // Search overlay helpers
+  const toggleSearch = (open) => {
+    if (!searchOverlay) return;
+    searchOverlay.setAttribute('aria-hidden', String(!open));
+    if (open) {
+      searchOverlay.querySelector('input[type="search"]')?.focus();
+    }
+  };
+  searchBtn?.addEventListener('click', () => toggleSearch(true));
+  searchClose?.addEventListener('click', () => toggleSearch(false));
 });


### PR DESCRIPTION
## Summary
- add js class helper for scripts
- implement sticky header, drawer, and search overlay behaviours

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1309be08328a6f9c159d6f78ac6