### PR TITLE
Improve header interactivity

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -1,4 +1,5 @@
 document.body.classList.remove('no-js');
+document.body.classList.add('js');
 
 // toggle verbose logging
 const DEBUG = false;

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,4 +1,83 @@
-/* Header interaction scripts */
-document.addEventListener('DOMContentLoaded', () => {
-  console.log('Fancy header script loaded');
+/**
+ * Interactivity for the fancy header.
+ * Handles sticky behaviour, mobile drawer and search overlay.
+ */
+
+document.addEventListener('DOMContentLoaded', function () {
+  var body   = document.body;
+  var header = document.getElementById('kc-header');
+  if (!header) {
+    body.classList.remove('no-js');
+    body.classList.add('js');
+    return;
+  }
+  var drawer = document.getElementById('kc-drawer');
+  var burger = document.querySelector('.kc-burger');
+  var drawerClose = document.querySelector('.kc-drawer-close');
+  var searchOverlay = document.querySelector('.kc-search');
+  var searchBtn   = document.querySelector('.kc-search-btn');
+  var searchClose = document.querySelector('.kc-search-close');
+
+  // Remove no-js marker and add js helper class
+  body.classList.remove('no-js');
+  body.classList.add('js');
+
+  // Sticky header toggle
+  var offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
+  var onScroll = function () {
+    var scrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
+    if (scrollY > offset) {
+      header.classList.add('kc--stuck');
+    } else {
+      header.classList.remove('kc--stuck');
+    }
+  };
+  window.addEventListener('scroll', onScroll);
+  onScroll();
+
+  // Drawer helpers
+  var toggleDrawer = function (open) {
+    if (!drawer) return;
+    drawer.setAttribute('aria-hidden', String(!open));
+    if (burger) {
+      burger.setAttribute('aria-expanded', String(open));
+    }
+    if (open) {
+      var focusable = drawer.querySelector('a,button');
+      if (focusable) {
+        focusable.focus();
+      }
+    }
+  };
+  if (burger) {
+    burger.addEventListener('click', function () { toggleDrawer(true); });
+  }
+  if (drawerClose) {
+    drawerClose.addEventListener('click', function () { toggleDrawer(false); });
+  }
+  if (drawer) {
+    drawer.addEventListener('click', function (e) {
+      if (e.target === drawer) {
+        toggleDrawer(false);
+      }
+    });
+  }
+
+  // Search overlay helpers
+  var toggleSearch = function (open) {
+    if (!searchOverlay) return;
+    searchOverlay.setAttribute('aria-hidden', String(!open));
+    if (open) {
+      var input = searchOverlay.querySelector('input[type="search"]');
+      if (input) {
+        input.focus();
+      }
+    }
+  };
+  if (searchBtn) {
+    searchBtn.addEventListener('click', function () { toggleSearch(true); });
+  }
+  if (searchClose) {
+    searchClose.addEventListener('click', function () { toggleSearch(false); });
+  }
 });

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -3,81 +3,78 @@
  * Handles sticky behaviour, mobile drawer and search overlay.
  */
 
-document.addEventListener('DOMContentLoaded', function () {
-  var body   = document.body;
-  var header = document.getElementById('kc-header');
-  if (!header) {
-    body.classList.remove('no-js');
-    body.classList.add('js');
-    return;
-  }
-  var drawer = document.getElementById('kc-drawer');
-  var burger = document.querySelector('.kc-burger');
-  var drawerClose = document.querySelector('.kc-drawer-close');
-  var searchOverlay = document.querySelector('.kc-search');
-  var searchBtn   = document.querySelector('.kc-search-btn');
-  var searchClose = document.querySelector('.kc-search-close');
+document.addEventListener('DOMContentLoaded', () => {
+  const body         = document.body;
+  const header       = document.getElementById('kc-header');
+  const drawer       = document.getElementById('kc-drawer');
+  const burger       = document.querySelector('.kc-burger');
+  const drawerClose  = document.querySelector('.kc-drawer-close');
+  const searchOverlay= document.querySelector('.kc-search');
+  const searchBtn    = document.querySelector('.kc-search-btn');
+  const searchClose  = document.querySelector('.kc-search-close');
 
-  // Remove no-js marker and add js helper class
+  // JS helpers
   body.classList.remove('no-js');
   body.classList.add('js');
 
+  // If header not present, nothing to wire
+  if (!header) return;
+
   // Sticky header toggle
-  var offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
-  var onScroll = function () {
-    var scrollY = window.pageYOffset || document.documentElement.scrollTop || 0;
-    if (scrollY > offset) {
+  const offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
+  const onScroll = () => {
+    if ((window.pageYOffset || document.documentElement.scrollTop || 0) > offset) {
       header.classList.add('kc--stuck');
+      header.classList.remove('kc-header--transparent');
     } else {
       header.classList.remove('kc--stuck');
+      header.classList.add('kc-header--transparent');
     }
   };
-  window.addEventListener('scroll', onScroll);
+  window.addEventListener('scroll', onScroll, { passive: true });
   onScroll();
 
+  // Scroll lock helpers
+  const lockScroll = () => { document.documentElement.style.overflow = 'hidden'; };
+  const unlockScroll = () => { document.documentElement.style.overflow = ''; };
+
   // Drawer helpers
-  var toggleDrawer = function (open) {
+  const toggleDrawer = (open) => {
     if (!drawer) return;
     drawer.setAttribute('aria-hidden', String(!open));
-    if (burger) {
-      burger.setAttribute('aria-expanded', String(open));
-    }
+    burger?.setAttribute('aria-expanded', String(open));
     if (open) {
-      var focusable = drawer.querySelector('a,button');
-      if (focusable) {
-        focusable.focus();
-      }
+      lockScroll();
+      drawer.querySelector('a,button')?.focus();
+    } else {
+      unlockScroll();
     }
   };
-  if (burger) {
-    burger.addEventListener('click', function () { toggleDrawer(true); });
-  }
-  if (drawerClose) {
-    drawerClose.addEventListener('click', function () { toggleDrawer(false); });
-  }
-  if (drawer) {
-    drawer.addEventListener('click', function (e) {
-      if (e.target === drawer) {
-        toggleDrawer(false);
-      }
-    });
-  }
+  burger?.addEventListener('click', () => toggleDrawer(true));
+  drawerClose?.addEventListener('click', () => toggleDrawer(false));
+  drawer?.addEventListener('click', (e) => { if (e.target === drawer) toggleDrawer(false); });
 
   // Search overlay helpers
-  var toggleSearch = function (open) {
+  const toggleSearch = (open) => {
     if (!searchOverlay) return;
     searchOverlay.setAttribute('aria-hidden', String(!open));
     if (open) {
-      var input = searchOverlay.querySelector('input[type="search"]');
-      if (input) {
-        input.focus();
-      }
+      lockScroll();
+      (searchOverlay.querySelector('input[type="search"]') ||
+       searchOverlay.querySelector('input[type="text"]'))?.focus();
+    } else {
+      unlockScroll();
     }
   };
-  if (searchBtn) {
-    searchBtn.addEventListener('click', function () { toggleSearch(true); });
-  }
-  if (searchClose) {
-    searchClose.addEventListener('click', function () { toggleSearch(false); });
-  }
+  searchBtn?.addEventListener('click', () => toggleSearch(true));
+  searchClose?.addEventListener('click', () => toggleSearch(false));
+  searchOverlay?.addEventListener('click', (e) => { if (e.target === searchOverlay) toggleSearch(false); });
+
+  // ESC closes drawer/search
+  window.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      toggleDrawer(false);
+      toggleSearch(false);
+    }
+  });
 });

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -3,26 +3,21 @@
  * Handles sticky behaviour, mobile drawer and search overlay.
  */
 
-document.addEventListener('DOMContentLoaded', () => {
-  const body         = document.body;
-  const header       = document.getElementById('kc-header');
-  const drawer       = document.getElementById('kc-drawer');
-  const burger       = document.querySelector('.kc-burger');
-  const drawerClose  = document.querySelector('.kc-drawer-close');
-  const searchOverlay= document.querySelector('.kc-search');
-  const searchBtn    = document.querySelector('.kc-search-btn');
-  const searchClose  = document.querySelector('.kc-search-close');
-
-  // JS helpers
-  body.classList.remove('no-js');
-  body.classList.add('js');
+document.addEventListener('DOMContentLoaded', function () {
+  var header       = document.getElementById('kc-header');
+  var drawer       = document.getElementById('kc-drawer');
+  var burger       = document.querySelector('.kc-burger');
+  var drawerClose  = document.querySelector('.kc-drawer-close');
+  var searchOverlay= document.querySelector('.kc-search');
+  var searchBtn    = document.querySelector('.kc-search-btn');
+  var searchClose  = document.querySelector('.kc-search-close');
 
   // If header not present, nothing to wire
   if (!header) return;
 
   // Sticky header toggle
-  const offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
-  const onScroll = () => {
+  var offset = (window.KC_HEADER && window.KC_HEADER.stickyOffset) || 64;
+  function onScroll() {
     if ((window.pageYOffset || document.documentElement.scrollTop || 0) > offset) {
       header.classList.add('kc--stuck');
       header.classList.remove('kc-header--transparent');
@@ -30,48 +25,50 @@ document.addEventListener('DOMContentLoaded', () => {
       header.classList.remove('kc--stuck');
       header.classList.add('kc-header--transparent');
     }
-  };
+  }
   window.addEventListener('scroll', onScroll, { passive: true });
   onScroll();
 
   // Scroll lock helpers
-  const lockScroll = () => { document.documentElement.style.overflow = 'hidden'; };
-  const unlockScroll = () => { document.documentElement.style.overflow = ''; };
+  function lockScroll() { document.documentElement.style.overflow = 'hidden'; }
+  function unlockScroll() { document.documentElement.style.overflow = ''; }
 
   // Drawer helpers
-  const toggleDrawer = (open) => {
+  function toggleDrawer(open) {
     if (!drawer) return;
     drawer.setAttribute('aria-hidden', String(!open));
-    burger?.setAttribute('aria-expanded', String(open));
+    if (burger) burger.setAttribute('aria-expanded', String(open));
     if (open) {
       lockScroll();
-      drawer.querySelector('a,button')?.focus();
+      var focusTarget = drawer.querySelector('a,button');
+      if (focusTarget) focusTarget.focus();
     } else {
       unlockScroll();
     }
-  };
-  burger?.addEventListener('click', () => toggleDrawer(true));
-  drawerClose?.addEventListener('click', () => toggleDrawer(false));
-  drawer?.addEventListener('click', (e) => { if (e.target === drawer) toggleDrawer(false); });
+  }
+  if (burger) burger.addEventListener('click', function () { toggleDrawer(true); });
+  if (drawerClose) drawerClose.addEventListener('click', function () { toggleDrawer(false); });
+  if (drawer) drawer.addEventListener('click', function (e) { if (e.target === drawer) toggleDrawer(false); });
 
   // Search overlay helpers
-  const toggleSearch = (open) => {
+  function toggleSearch(open) {
     if (!searchOverlay) return;
     searchOverlay.setAttribute('aria-hidden', String(!open));
     if (open) {
       lockScroll();
-      (searchOverlay.querySelector('input[type="search"]') ||
-       searchOverlay.querySelector('input[type="text"]'))?.focus();
+      var input = searchOverlay.querySelector('input[type="search"]') ||
+                  searchOverlay.querySelector('input[type="text"]');
+      if (input) input.focus();
     } else {
       unlockScroll();
     }
-  };
-  searchBtn?.addEventListener('click', () => toggleSearch(true));
-  searchClose?.addEventListener('click', () => toggleSearch(false));
-  searchOverlay?.addEventListener('click', (e) => { if (e.target === searchOverlay) toggleSearch(false); });
+  }
+  if (searchBtn) searchBtn.addEventListener('click', function () { toggleSearch(true); });
+  if (searchClose) searchClose.addEventListener('click', function () { toggleSearch(false); });
+  if (searchOverlay) searchOverlay.addEventListener('click', function (e) { if (e.target === searchOverlay) toggleSearch(false); });
 
   // ESC closes drawer/search
-  window.addEventListener('keydown', (e) => {
+  window.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') {
       toggleDrawer(false);
       toggleSearch(false);


### PR DESCRIPTION
## Summary
- add js class helper for scripts
- implement sticky header, drawer, and search overlay behaviours
- ensure header script runs without optional chaining and exits gracefully when header markup is missing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ace1309be08328a6f9c159d6f78ac6