### PR TITLE
Fix fancy header template reference

### DIFF
--- a/header.php
+++ b/header.php
@@ -14,4 +14,4 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
-<?php get_template_part( 'template-parts/header-fancy' ); ?>
+<?php get_template_part( 'template-parts/header', 'fancy' ); ?>


### PR DESCRIPTION
## Summary
- Load `header-fancy` template via slug/name to enable fallback to default header

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae1f8660788328888a9c9bb4e698c6