### PR TITLE
fix: load child theme block patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -65,3 +65,20 @@ add_filter( 'body_class', function( $classes ){
   return $classes;
 } );
 
+/**
+ * Register custom block pattern category and load pattern definitions.
+ */
+add_action( 'init', function() {
+  register_block_pattern_category(
+    'kadence-child',
+    array( 'label' => __( 'Kadence Child', 'kadence-child' ) )
+  );
+
+  $pattern_dir = get_theme_file_path( 'inc/patterns' );
+  if ( is_dir( $pattern_dir ) ) {
+    foreach ( glob( $pattern_dir . '/*.php' ) as $pattern ) {
+      include $pattern;
+    }
+  }
+} );
+

--- a/inc/patterns/carousel-3d-ring.php
+++ b/inc/patterns/carousel-3d-ring.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Pattern: 3D Logo Carousel – Ring
+ */
+
+ob_start();
+include get_theme_file_path( 'patterns/carousel-3d-ring.php' );
+$pattern_content = ob_get_clean();
+
+register_block_pattern(
+    'kadence-child/carousel-3d-ring',
+    [
+        'title'       => __( '3D Logo Carousel – Ring', 'kadence-child' ),
+        'description' => __( '3D rotating ring of logos with autoplay and hover pause.', 'kadence-child' ),
+        'categories'  => [ 'kadence-child' ],
+        'content'     => $pattern_content,
+    ]
+);


### PR DESCRIPTION
## Summary
- register custom `kadence-child` pattern category
- load all child theme pattern definitions on init

## Testing
- `find . -name "*.php" -not -path './vendor/*' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68ae4c3afdc4832898c195895e90f250