### PR TITLE
Load utilities and sanitize WooCommerce cart output

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,8 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) { exit; }
 
+require_once get_theme_file_path( 'utils.php' );
+
 /**
  * Enqueue child + header assets
  */
@@ -62,8 +64,8 @@ add_action( 'after_setup_theme', function() {
 if ( class_exists( 'WooCommerce' ) ) {
   add_filter( 'woocommerce_add_to_cart_fragments', function( $fragments ) {
     ob_start(); ?>
-    <span class="kc-cart-count" data-count="<?php echo WC()->cart->get_cart_contents_count(); ?>">
-      <?php echo WC()->cart->get_cart_contents_count(); ?>
+    <span class="kc-cart-count" data-count="<?php echo esc_attr( WC()->cart->get_cart_contents_count() ); ?>">
+      <?php echo esc_html( WC()->cart->get_cart_contents_count() ); ?>
     </span>
     <?php
     $fragments['span.kc-cart-count'] = ob_get_clean();

--- a/template-parts/header-fancy.php
+++ b/template-parts/header-fancy.php
@@ -41,7 +41,7 @@ $logo    = $logo_id ? wp_get_attachment_image( $logo_id, 'full', false, array('c
     <div class="kc-container">
 
       <div class="kc-left">
-        <a class="kc-brand" href="<?php echo esc_url( home_url('/') ); ?>" aria-label="<?php bloginfo('name'); ?>">
+        <a class="kc-brand" href="<?php echo esc_url( home_url( '/' ) ); ?>" aria-label="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>">
           <?php
             if ( $logo ) {
               echo $logo;
@@ -72,8 +72,8 @@ $logo    = $logo_id ? wp_get_attachment_image( $logo_id, 'full', false, array('c
         <?php if ( $has_woo ) : ?>
           <a class="kc-cart" href="<?php echo esc_url( wc_get_cart_url() ); ?>" aria-label="Cart">
             <svg aria-hidden="true" class="kc-ico"><use href="#ico-cart"></use></svg>
-            <span class="kc-cart-count" data-count="<?php echo WC()->cart->get_cart_contents_count(); ?>">
-              <?php echo WC()->cart->get_cart_contents_count(); ?>
+            <span class="kc-cart-count" data-count="<?php echo esc_attr( WC()->cart->get_cart_contents_count() ); ?>">
+              <?php echo esc_html( WC()->cart->get_cart_contents_count() ); ?>
             </span>
           </a>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- load `utils.php` to expose helper functions like `kc_get_theme_version`
- sanitize WooCommerce cart count output in theme functions and header template
- escape site name used in header aria-label

## Testing
- `php -l functions.php`
- `php -l template-parts/header-fancy.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68ae5690e6a48328967c2ca6c7f82886