### PR TITLE
Add skip link for improved header accessibility

### DIFF
--- a/header.php
+++ b/header.php
@@ -13,4 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
+<a class="kc-skip-link" href="#primary"><?php esc_html_e( 'Skip to content', 'kadence-child' ); ?></a>
+
 <?php get_template_part( 'template-parts/header-fancy' ); ?>

--- a/style.css
+++ b/style.css
@@ -10,6 +10,21 @@
 .site-footer { background: #f5f5f5; }
 
 /* Your custom CSS below */
+/* Accessibility: visible skip link */
+.kc-skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: #fff;
+  padding: 8px 12px;
+  z-index: 1000;
+  transition: top .2s ease;
+}
+.kc-skip-link:focus {
+  top: 0;
+}
+
 /* ==== HERO ULTIMATE ==== */
 .kc-hero-ultimate { position:relative; min-height:45vh; }
 .kc-hero-ultimate .wp-block-cover__background{ background:linear-gradient(90deg, rgba(0,0,0,0.65), transparent); opacity:1!important; }


### PR DESCRIPTION
## Summary
- add a skip-to-content link at the top of the header
- style skip link so it becomes visible when focused

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l header.php`
- `php -l template-parts/header-fancy.php`


------
https://chatgpt.com/codex/tasks/task_e_68ae7a6d02248328aa38fe7be3d6a43a