### PR TITLE
Add skip link and theme toggle for header

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -33,11 +33,19 @@
   --z-search: 1000;
 }
 
+:root[data-theme="light"]{
+  --kc-text:#0e1622; --kc-text-dim:#3a4b62;
+  --kc-bg:#ffffff; --kc-bg-2:#f8fafc; --kc-surface:#ffffff;
+  --kc-border:rgba(0,0,0,.12); --kc-glass:rgba(255,255,255,.7);
+  --kc-link:#0e1622;
+}
+
 @media (prefers-color-scheme: light){
-  :root{
+  :root:not([data-theme]){
     --kc-text:#0e1622; --kc-text-dim:#3a4b62;
     --kc-bg:#ffffff; --kc-bg-2:#f8fafc; --kc-surface:#ffffff;
     --kc-border:rgba(0,0,0,.12); --kc-glass:rgba(255,255,255,.7);
+    --kc-link:#0e1622;
   }
 }
 

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -12,6 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchOverlay = document.querySelector('.kc-search');
   const searchBtn     = document.querySelector('.kc-search-btn');
   const searchClose   = document.querySelector('.kc-search-close');
+  const themeToggle   = document.querySelector('.kc-theme-toggle');
+  const themeIcon     = themeToggle?.querySelector('use');
 
   // JS helpers
   body.classList.remove('no-js');
@@ -77,6 +79,21 @@ document.addEventListener('DOMContentLoaded', () => {
       toggleDrawer(false);
       toggleSearch(false);
     }
+  });
+
+  // Theme toggle
+  const root = document.documentElement;
+  const applyTheme = (mode) => {
+    root.setAttribute('data-theme', mode);
+    localStorage.setItem('kc-theme', mode);
+    themeIcon?.setAttribute('href', mode === 'light' ? '#ico-moon' : '#ico-sun');
+    themeToggle?.setAttribute('aria-label', mode === 'light' ? 'Activate dark mode' : 'Activate light mode');
+  };
+  const storedTheme = localStorage.getItem('kc-theme') || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+  applyTheme(storedTheme);
+  themeToggle?.addEventListener('click', () => {
+    const current = root.getAttribute('data-theme') || 'dark';
+    applyTheme(current === 'light' ? 'dark' : 'light');
   });
 });
 

--- a/header.php
+++ b/header.php
@@ -13,4 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 <body <?php body_class(); ?>>
 <?php wp_body_open(); ?>
 
+<a class="kc-skip-link" href="#primary"><?php esc_html_e( 'Skip to content', 'kadence-child' ); ?></a>
+
 <?php get_template_part( 'template-parts/header-fancy' ); ?>

--- a/style.css
+++ b/style.css
@@ -10,6 +10,30 @@
 .site-footer { background: #f5f5f5; }
 
 /* Your custom CSS below */
+/* Accessibility: visible skip link */
+.kc-skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: #fff;
+  padding: 8px 12px;
+  z-index: 1000;
+  transition: top .2s ease;
+}
+.kc-skip-link:focus {
+  top: 0;
+}
+
+/* Global colors (tied to header theme vars) */
+body {
+  background: var(--kc-bg);
+  color: var(--kc-text);
+}
+a {
+  color: var(--kc-link);
+}
+
 /* ==== HERO ULTIMATE ==== */
 .kc-hero-ultimate { position:relative; min-height:45vh; }
 .kc-hero-ultimate .wp-block-cover__background{ background:linear-gradient(90deg, rgba(0,0,0,0.65), transparent); opacity:1!important; }

--- a/template-parts/header-fancy.php
+++ b/template-parts/header-fancy.php
@@ -29,7 +29,7 @@ $logo    = $logo_id ? wp_get_attachment_image( $logo_id, 'full', false, array('c
           <svg aria-hidden="true" class="kc-ico"><use href="#ico-pin"></use></svg>
           <span>Visit Our Showroom</span>
         </a>
-        <button class="kc-theme-toggle" aria-label="Toggle dark mode">
+        <button class="kc-theme-toggle" aria-label="Toggle theme">
           <svg aria-hidden="true" class="kc-ico"><use href="#ico-moon"></use></svg>
         </button>
       </div>
@@ -154,6 +154,7 @@ $logo    = $logo_id ? wp_get_attachment_image( $logo_id, 'full', false, array('c
     <symbol id="ico-phone" viewBox="0 0 24 24"><path d="M6.6 10.8c1.5 2.9 3.8 5.1 6.7 6.7l2.2-2.2c.3-.3.8-.4 1.1-.2 1.2.4 2.6.7 4 .7.6 0 1 .4 1 1v3.6c0 .6-.4 1-1 1C11.1 21.4 2.6 12.9 2.6 2.4c0-.6.4-1 1-1H7c.6 0 1 .4 1 1 0 1.4.2 2.8.7 4 .1.4 0 .8-.3 1.1l-1.8 2.3z"/></symbol>
     <symbol id="ico-pin" viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 1 7 7c0 5.2-7 13-7 13S5 14.2 5 9a7 7 0 0 1 7-7zm0 9.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/></symbol>
     <symbol id="ico-moon" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z"/></symbol>
+    <symbol id="ico-sun" viewBox="0 0 24 24"><path d="M12 4V1m0 22v-3m10-10h3M1 12h3m15.5-6.5 2.1-2.1M3.4 20.6l2.1-2.1m0-12L3.4 3.4M20.6 20.6l-2.1-2.1M12 8a4 4 0 1 1 0 8 4 4 0 0 1 0-8z"/></symbol>
     <symbol id="ico-search" viewBox="0 0 24 24"><path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16zm11 19-5.3-5.3"/></symbol>
     <symbol id="ico-cart" viewBox="0 0 24 24"><path d="M7 22a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm10 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2zM3 3h2l2.6 12.2A2 2 0 0 0 9.6 17h8.9a2 2 0 0 0 2-1.6l1.3-7.4H6.2"/></symbol>
     <symbol id="ico-arrow" viewBox="0 0 24 24"><path d="M4 12h16M12 4l8 8-8 8"/></symbol>


### PR DESCRIPTION
## Summary
- add a skip-to-content link at the top of the header
- enable light/dark theme toggle with stored preference
- expose header color variables for global body and link styling

## Testing
- `php -l header.php`
- `php -l template-parts/header-fancy.php`
- `node --check assets/js/header.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7a6d02248328aa38fe7be3d6a43a