### PR TITLE
Improve desktop submenu accessibility

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -111,6 +111,7 @@
   border-radius:var(--kc-radius); box-shadow:var(--kc-shadow); display:none;
 }
 .kc-menu > li:hover > .kc-sub{ display:block; }
+.kc-menu > li > button[aria-expanded="true"] + .kc-sub{ display:block; }
 .kc-sub li{ list-style:none; }
 .kc-sub a{ display:flex; padding:10px 12px; gap:10px; color:var(--kc-text); text-decoration:none; border-radius:10px; }
 .kc-sub a:hover{ background:rgba(255,255,255,.06); }

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -71,11 +71,48 @@ document.addEventListener('DOMContentLoaded', () => {
   searchClose?.addEventListener('click', () => toggleSearch(false));
   searchOverlay?.addEventListener('click', (e) => { if (e.target === searchOverlay) toggleSearch(false); });
 
+  // Submenu toggles
+  const menuButtons = header.querySelectorAll('.kc-nav .menu-item-has-children > button');
+  menuButtons.forEach((btn) => {
+    const li = btn.parentElement;
+    const close = () => btn.setAttribute('aria-expanded', 'false');
+
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      menuButtons.forEach((b) => b.setAttribute('aria-expanded', 'false'));
+      btn.setAttribute('aria-expanded', String(!expanded));
+    });
+
+    btn.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        btn.click();
+      } else if (e.key === 'Escape') {
+        close();
+      }
+    });
+
+    li?.addEventListener('focusout', (e) => {
+      if (!li.contains(e.relatedTarget)) {
+        close();
+      }
+    });
+
+    const submenu = document.getElementById(btn.getAttribute('aria-controls'));
+    submenu?.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        close();
+        btn.focus();
+      }
+    });
+  });
+
   // ESC closes drawer/search
   window.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
       toggleDrawer(false);
       toggleSearch(false);
+      menuButtons.forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
     }
   });
 });


### PR DESCRIPTION
## Summary
- render top-level items with children as buttons tied to their submenus via ARIA
- toggle header submenus via click/keyboard and close on focus loss or Escape
- reveal submenus when parent buttons are expanded

## Testing
- `php -l template-parts/header-fancy.php`
- `node --check assets/js/header.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68aef2f961b88328978d2c203b1dfdb2