### PR TITLE
feat: dynamic dark mode toggle label and icon

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -12,6 +12,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const searchOverlay = document.querySelector('.kc-search');
   const searchBtn     = document.querySelector('.kc-search-btn');
   const searchClose   = document.querySelector('.kc-search-close');
+  const themeToggle   = document.querySelector('.kc-theme-toggle');
+  const themeIcon     = themeToggle?.querySelector('use');
+  const prefersDark   = window.matchMedia('(prefers-color-scheme: dark)');
 
   // JS helpers
   body.classList.remove('no-js');
@@ -70,6 +73,40 @@ document.addEventListener('DOMContentLoaded', () => {
   searchBtn?.addEventListener('click', () => toggleSearch(true));
   searchClose?.addEventListener('click', () => toggleSearch(false));
   searchOverlay?.addEventListener('click', (e) => { if (e.target === searchOverlay) toggleSearch(false); });
+
+  // Theme toggle helpers
+  const getTheme = () => document.documentElement.getAttribute('data-theme') || (prefersDark.matches ? 'dark' : 'light');
+  const applyThemeLabel = (theme) => {
+    themeToggle?.setAttribute('aria-label', theme === 'dark' ? 'Activate light mode' : 'Activate dark mode');
+    themeIcon?.setAttribute('href', theme === 'dark' ? '#ico-sun' : '#ico-moon');
+  };
+  const setTheme = (theme, persist = true) => {
+    document.documentElement.setAttribute('data-theme', theme);
+    if (persist) localStorage.setItem('kc-theme', theme);
+    applyThemeLabel(theme);
+  };
+
+  const savedTheme = localStorage.getItem('kc-theme');
+  if (savedTheme) {
+    document.documentElement.setAttribute('data-theme', savedTheme);
+    applyThemeLabel(savedTheme);
+  } else {
+    applyThemeLabel(getTheme());
+  }
+
+  themeToggle?.addEventListener('click', () => {
+    const next = getTheme() === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+  });
+
+  prefersDark.addEventListener('change', (e) => {
+    if (!localStorage.getItem('kc-theme')) {
+      applyThemeLabel(e.matches ? 'dark' : 'light');
+    }
+  });
+
+  const observer = new MutationObserver(() => applyThemeLabel(getTheme()));
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 
   // Submenu toggles
   const menuButtons = header.querySelectorAll('.kc-nav .menu-item-has-children > button');

--- a/template-parts/header-fancy.php
+++ b/template-parts/header-fancy.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'KC_Primary_Walker' ) ) {
           <svg aria-hidden="true" class="kc-ico"><use href="#ico-pin"></use></svg>
           <span>Visit Our Showroom</span>
         </a>
-        <button class="kc-theme-toggle" aria-label="Toggle dark mode">
+        <button class="kc-theme-toggle" aria-label="Activate dark mode">
           <svg aria-hidden="true" class="kc-ico"><use href="#ico-moon"></use></svg>
         </button>
       </div>
@@ -190,6 +190,10 @@ if ( ! class_exists( 'KC_Primary_Walker' ) ) {
     <symbol id="ico-phone" viewBox="0 0 24 24"><path d="M6.6 10.8c1.5 2.9 3.8 5.1 6.7 6.7l2.2-2.2c.3-.3.8-.4 1.1-.2 1.2.4 2.6.7 4 .7.6 0 1 .4 1 1v3.6c0 .6-.4 1-1 1C11.1 21.4 2.6 12.9 2.6 2.4c0-.6.4-1 1-1H7c.6 0 1 .4 1 1 0 1.4.2 2.8.7 4 .1.4 0 .8-.3 1.1l-1.8 2.3z"/></symbol>
     <symbol id="ico-pin" viewBox="0 0 24 24"><path d="M12 2a7 7 0 0 1 7 7c0 5.2-7 13-7 13S5 14.2 5 9a7 7 0 0 1 7-7zm0 9.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z"/></symbol>
     <symbol id="ico-moon" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z"/></symbol>
+    <symbol id="ico-sun" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="5"/>
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+    </symbol>
     <symbol id="ico-search" viewBox="0 0 24 24"><path d="M10 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16zm11 19-5.3-5.3"/></symbol>
     <symbol id="ico-cart" viewBox="0 0 24 24"><path d="M7 22a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm10 0a1 1 0 1 1 0-2 1 1 0 0 1 0 2zM3 3h2l2.6 12.2A2 2 0 0 0 9.6 17h8.9a2 2 0 0 0 2-1.6l1.3-7.4H6.2"/></symbol>
     <symbol id="ico-arrow" viewBox="0 0 24 24"><path d="M4 12h16M12 4l8 8-8 8"/></symbol>


### PR DESCRIPTION
## Summary
- Initialize theme toggle with appropriate `aria-label` and icon
- Track color scheme changes and persist user preference

## Testing
- `php -l template-parts/header-fancy.php`
- `node --check assets/js/header.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aef49f89848328839d71af3993ea9a