### PR TITLE
Add JS fallback for hero carousel logos

### DIFF
--- a/assets/child.js
+++ b/assets/child.js
@@ -53,6 +53,7 @@ const DEBUG = false;
     CLEANUPS.get(ring)?.();
 
     const stage = ring.closest('.es-stage');
+    const fallback = stage?.nextElementSibling;
     const tiles = $$('.es-tile', ring);
     if (!tiles.length) return;
 
@@ -75,7 +76,9 @@ const DEBUG = false;
     if (stage) {
       const h = Math.round(Math.max(180, Math.min(sw * 0.5, 320)));
       stage.style.height = h + 'px';
+      stage.classList.add('is-ready');
     }
+    if (fallback) fallback.classList.add('is-hidden');
 
     // JS rotation + face-camera cards
     const reduced = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)').matches : false;

--- a/patterns/hero-ultimate.php
+++ b/patterns/hero-ultimate.php
@@ -124,6 +124,25 @@
             <div class="es-tile"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Caesarstone-01-scaled.png" alt="Caesarstone"></div>
           </div>
         </div>
+        <div class="es-fallback">
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Wilsonart-01.png" alt="Wilsonart"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vicostone-01.png" alt="Vicostone"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Viatera-01.png" alt="Viatera"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Vadara-Capture-the-world-in-quartz-01.png" alt="Vadara"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/UGM-Surfaces-01.png" alt="UGM Surfaces"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Trends-01.png" alt="Trends"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Teracanto-01.png" alt="Teracanto"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Silestone-01.png" alt="Silestone"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Q-Quartz-01.png" alt="Q Quartz"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Pionite-01.png" alt="Pionite"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Nevamar-01.png" alt="Nevamar"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Hi-Macs-01.png" alt="HI-MACS"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Formica-01.png" alt="Formica"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Dekton-01.png" alt="Dekton"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Corian-01.png" alt="Corian"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Cambria-01.png" alt="Cambria"></div>
+          <div class="es-card"><img src="https://elevatedcountertopexperts.com/wp-content/uploads/2025/08/Caesarstone-01-scaled.png" alt="Caesarstone"></div>
+        </div>
         <!-- /wp:html -->
       </div>
       <!-- /wp:group -->

--- a/style.css
+++ b/style.css
@@ -85,8 +85,9 @@
 .es-stage{
   position:relative; width:100%;
   height:clamp(120px,26vw,240px); perspective:clamp(900px,160vw,1400px); perspective-origin:50% 42%;
-  overflow:visible;
+  overflow:visible; display:none;
 }
+.es-stage.is-ready{ display:block; }
 .es-ring{
   position:absolute; top:50%; left:50%;
   transform-style:preserve-3d;
@@ -108,15 +109,14 @@
 }
 .es-card img{ display:block; width:100%; height:100%; object-fit:cover; }
 
-/* ===== No-JS fallbacks ===== */
+/* ===== Logo fallbacks ===== */
 .es-fallback{
-  display:none;
+  display:grid;
   grid-template-columns:repeat(auto-fit,minmax(120px,1fr));
   gap:clamp(16px,3vw,24px);
   justify-items:center;
 }
-.no-js .es-stage{ display:none; }
-.no-js .es-fallback{ display:grid; }
+.es-fallback.is-hidden{ display:none; }
 
 /* ================================
    Hero — Showcase (with Carousel) styles


### PR DESCRIPTION
## Summary
- add hidden-by-default stage and visible fallback grid for hero carousel logos
- toggle visibility in carousel script when initialization succeeds

## Testing
- `php -l patterns/hero-ultimate.php`
- `node --check assets/child.js`

------
https://chatgpt.com/codex/tasks/task_e_68b05c445e5c8328ab26f2096763035f